### PR TITLE
Add guidance for non-App Store app launch issue

### DIFF
--- a/GatekeeperHelper/AppStoreFixView.swift
+++ b/GatekeeperHelper/AppStoreFixView.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+struct AppStoreFixView: View {
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // 标题栏 + 关闭按钮
+            HStack {
+                Text("解决方案：无法打开App，因为它不是从App Store下载")
+                    .font(.title2)
+                    .bold()
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button(action: dismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("这是由于Mac OS的软件安装安全性设置默认是仅允许安装来自「App Store 」的软件，进入设置调整修改即可。")
+
+                    Text("解决方式如下：")
+
+                    Text("1. 打开「系统设置」→「隐私与安全性」。\n2. 滚动到底部，在“安全性-允许以下来源的应用程序”处选择“App Store与已知开发者”后输入密码确认修改。\n3. 完成调整后即可运行相应App。\n\n你也可通过本软件第一个App启动问题中的“永久禁用Gatekeeper”功能，获得把该设置改为“任何来源”的权限。否则，Apple出于安全考虑不展示此选项。")
+
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.1))
+                        .frame(height: 180)
+                        .overlay(
+                            Text("【图片占位】展示设置中“App Store与已知开发者”选项位置")
+                                .foregroundColor(.gray)
+                        )
+                }
+                .font(.body)
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button("跳转至设置界面") {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?General") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 620, minHeight: 460)
+    }
+}

--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -49,6 +49,11 @@ let knownIssues: [UnlockIssue] = [
         title: "应用程序“xxx”无法打开。",
         description: "macOS 的安全机制针对某些第三方 App 是“带壳”的，此时这些软件将提示“应用程序\"xxx\"无法打开”。通过引入第三方工具进行脱壳操作即可正常打开。",
         imageName: "issue5-placeholder",
+    ),
+    UnlockIssue(
+        title: "无法打开“xxx”，因为它不是从App Store下载。",
+        description: "如果 Mac 是全新的或从未更改过软件安装安全性设置，其默认设置是仅允许安装来自「App Store 」的软件。而你正在安装的软件是从浏览器或其他第三方下载的时，就会看到这一警告信息。",
+        imageName: "issue6-placeholder",
     )
 ]
 
@@ -63,6 +68,7 @@ struct ContentView: View {
     @State private var showSettingsSheet = false
     @State private var showHistorySheet = false
     @State private var showMalwareFixSheet = false
+    @State private var showAppStoreFixSheet = false
 
     var body: some View {
         GeometryReader { _ in
@@ -178,6 +184,60 @@ struct ContentView: View {
                                 .sheet(isPresented: $showMalwareFixSheet) {
                                     MalwareCheckFixView {
                                         showMalwareFixSheet = false
+                                    }
+                                }
+                            } else if issue.title == "无法打开“xxx”，因为它不是从App Store下载。" {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text(issue.title)
+                                        .font(.title2)
+                                        .bold()
+                                    ScrollView {
+                                        Text(issue.description)
+                                            .font(.body)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                    .frame(minHeight: 50, maxHeight: 120)
+
+                                    Rectangle()
+                                        .fill(Color.gray.opacity(0.15))
+                                        .frame(height: 150)
+                                        .overlay(
+                                            Text("【图片占位：\(issue.imageName)】")
+                                                .foregroundColor(.gray)
+                                        )
+
+                                    Divider()
+
+                                    HStack {
+                                        Spacer()
+                                        HStack {
+    Spacer()
+    VStack {
+        Spacer()
+        Button(action: {
+            showAppStoreFixSheet = true
+        }) {
+            Text("查看解决方案")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(minWidth: 180)
+        }
+        .padding()
+        .background(Color.accentColor.opacity(0.12))
+        .cornerRadius(10)
+        Spacer()
+    }
+    Spacer()
+}
+                                        .padding()
+                                        .background(Color.accentColor.opacity(0.1))
+                                        .cornerRadius(8)
+                                        Spacer()
+                                    }
+                                }
+                                .padding(.top, 6)
+                                .sheet(isPresented: $showAppStoreFixSheet) {
+                                    AppStoreFixView {
+                                        showAppStoreFixSheet = false
                                     }
                                 }
                             } else {


### PR DESCRIPTION
## Summary
- add new “无法打开“xxx”，因为它不是从App Store下载。” issue option with instructional sheet
- include AppStoreFixView to guide users to enable "App Store 与已知开发者"

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project GatekeeperHelper.xcodeproj -scheme GatekeeperHelper -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e69695308323ba66830b892085c3