### PR TITLE
feat: add unverified developer troubleshooting

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -54,6 +54,11 @@ let knownIssues: [UnlockIssue] = [
         title: "无法打开“xxx”，因为它不是从App Store下载。",
         description: "如果 Mac 是全新的或从未更改过软件安装安全性设置，其默认设置是仅允许安装来自「App Store 」的软件。而你正在安装的软件是从浏览器或其他第三方下载的时，就会看到这一警告信息。",
         imageName: "issue6-placeholder",
+    ),
+    UnlockIssue(
+        title: "无法打开“xxx”，因为无法验证开发者。",
+        description: "即便你的Mac已经允许安装App Store和已知开发者的应用，但当你尝试安装的某些App时，可能也还会看到此类警告。",
+        imageName: "issue7-placeholder",
     )
 ]
 
@@ -69,6 +74,7 @@ struct ContentView: View {
     @State private var showHistorySheet = false
     @State private var showMalwareFixSheet = false
     @State private var showAppStoreFixSheet = false
+    @State private var showUnverifiedDeveloperFixSheet = false
 
     var body: some View {
         GeometryReader { _ in
@@ -238,6 +244,60 @@ struct ContentView: View {
                                 .sheet(isPresented: $showAppStoreFixSheet) {
                                     AppStoreFixView {
                                         showAppStoreFixSheet = false
+                                    }
+                                }
+                            } else if issue.title == "无法打开“xxx”，因为无法验证开发者。" {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text(issue.title)
+                                        .font(.title2)
+                                        .bold()
+                                    ScrollView {
+                                        Text(issue.description)
+                                            .font(.body)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                    .frame(minHeight: 50, maxHeight: 120)
+
+                                    Rectangle()
+                                        .fill(Color.gray.opacity(0.15))
+                                        .frame(height: 150)
+                                        .overlay(
+                                            Text("【图片占位：\\(issue.imageName)】")
+                                                .foregroundColor(.gray)
+                                        )
+
+                                    Divider()
+
+                                    HStack {
+                                        Spacer()
+                                        HStack {
+    Spacer()
+    VStack {
+        Spacer()
+        Button(action: {
+            showUnverifiedDeveloperFixSheet = true
+        }) {
+            Text("查看解决方案")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(minWidth: 180)
+        }
+        .padding()
+        .background(Color.accentColor.opacity(0.12))
+        .cornerRadius(10)
+        Spacer()
+    }
+    Spacer()
+}
+                                        .padding()
+                                        .background(Color.accentColor.opacity(0.1))
+                                        .cornerRadius(8)
+                                        Spacer()
+                                    }
+                                }
+                                .padding(.top, 6)
+                                .sheet(isPresented: $showUnverifiedDeveloperFixSheet) {
+                                    UnverifiedDeveloperFixView {
+                                        showUnverifiedDeveloperFixSheet = false
                                     }
                                 }
                             } else {

--- a/GatekeeperHelper/UnverifiedDeveloperFixView.swift
+++ b/GatekeeperHelper/UnverifiedDeveloperFixView.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+struct UnverifiedDeveloperFixView: View {
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // 标题栏 + 关闭按钮
+            HStack {
+                Text("解决方案：无法打开App，因为无法验证开发者")
+                    .font(.title2)
+                    .bold()
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button(action: dismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("这是由于虽然mac OS的软件安装安全性设置已经允许安装App Store和已知开发者的应用，但由于某些应用不属于“已知开发者”范畴或一系列其他原因，使你仍然看到此类警告")
+
+                    Text("解决方式如下：")
+
+                    Text("1.右键点击对应App，选择打开，连续操作两次。\n2.再在访达中对应位置找到软件，选中并右击 打开。\n3.完成上述以后，之后就可以通过双击打开软件了。")
+
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.1))
+                        .frame(height: 180)
+                        .overlay(
+                            Text("【图片占位】展示访达中打开应用流程")
+                                .foregroundColor(.gray)
+                        )
+                }
+                .font(.body)
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button("跳转至访达界面") {
+                    let url = URL(fileURLWithPath: "/Applications")
+                    NSWorkspace.shared.open(url)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 620, minHeight: 460)
+    }
+}


### PR DESCRIPTION
## Summary
- add "无法打开“xxx”，因为无法验证开发者" issue option with guided fix
- create `UnverifiedDeveloperFixView` that instructs users to open apps from unidentified developers

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project GatekeeperHelper.xcodeproj -scheme GatekeeperHelper -sdk macosx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689421f385788323a9b03b77437a9549