### PR TITLE
Add alternate malware warning option

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -59,6 +59,11 @@ let knownIssues: [UnlockIssue] = [
         title: "无法打开“xxx”，因为无法验证开发者。",
         description: "即便你的Mac已经允许安装App Store和已知开发者的应用，但当你尝试安装的某些App时，可能也还会看到此类警告。",
         imageName: "issue7-placeholder",
+    ),
+    UnlockIssue(
+        title: "Apple无法验证“xxx”是否包含可能危害Mac安全或泄漏隐私的恶意软件",
+        description: "此问题是“无法打开“xxx”，因为 Apple 无法检查其是否包含恶意软件”的另一种表述。macOS Catalina 及更高版本要求 App 必须通过 Apple 的公证（Notarization）验证，未通过验证会提示类似此警告，解决方法与前者相同。",
+        imageName: "issue8-placeholder",
     )
 ]
 
@@ -138,7 +143,7 @@ struct ContentView: View {
 
                     VStack(alignment: .leading, spacing: 16) {
                         if let issue = selectedIssue {
-                            if issue.title == "无法打开“xxx”，因为 Apple 无法检查其是否包含恶意软件。" {
+                            if issue.title == "无法打开“xxx”，因为 Apple 无法检查其是否包含恶意软件。" || issue.title == "Apple无法验证“xxx”是否包含可能危害Mac安全或泄漏隐私的恶意软件" {
                                 VStack(alignment: .leading, spacing: 12) {
                                     Text(issue.title)
                                         .font(.title2)
@@ -188,7 +193,10 @@ struct ContentView: View {
                                 }
                                 .padding(.top, 6)
                                 .sheet(isPresented: $showMalwareFixSheet) {
-                                    MalwareCheckFixView {
+                                    let sheetTitle = issue.title == "无法打开“xxx”，因为 Apple 无法检查其是否包含恶意软件。" ?
+                                        "解决方案：无法打开 App，因为 Apple 无法检查其是否包含恶意软件" :
+                                        "解决方案：Apple无法验证App是否包含可能危害Mac安全或泄漏隐私的恶意软件"
+                                    MalwareCheckFixView(title: sheetTitle) {
                                         showMalwareFixSheet = false
                                     }
                                 }

--- a/GatekeeperHelper/MalwareCheckFixView.swift
+++ b/GatekeeperHelper/MalwareCheckFixView.swift
@@ -10,13 +10,14 @@ import SwiftUI
 import AppKit
 
 struct MalwareCheckFixView: View {
+    var title: String
     var dismiss: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             // 标题栏 + 关闭按钮
             HStack {
-                Text("解决方案：无法打开 App，因为 Apple 无法检查其是否包含恶意软件")
+                Text(title)
                     .font(.title2)
                     .bold()
                     .lineLimit(2)


### PR DESCRIPTION
## Summary
- add issue for "Apple无法验证" malware warning
- display same solution as existing "无法检查是否包含恶意软件" case
- generalize malware fix view with configurable title

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6895dac6acb08323b7e22a5a341f0799