### PR TITLE
feat: add keychain password prompt guidance

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -74,6 +74,11 @@ let knownIssues: [UnlockIssue] = [
         title: "无法打开“xxx”，因为“安全策略”已设为“某某安全性”",
         description: "此问题常出现在安装某些涉及较高权限的App或非正版App时，需要进入Mac恢复模式才能进行修改，并且一般情况下不建议进行修改。",
         imageName: "issue10-placeholder",
+    ),
+    UnlockIssue(
+        title: "启动软件时一直弹窗输入密码或存储密码/钥匙串",
+        description: "有些时候mac OS的“密码/钥匙串”功能会出现崩溃或报错，而导致启动某些App时频繁弹窗提示存储钥匙串，大多数情况下进入访达清空对应软件的钥匙串文件就可解决这一问题。",
+        imageName: "issue11-placeholder",
     )
 ]
 
@@ -92,6 +97,7 @@ struct ContentView: View {
     @State private var showUnverifiedDeveloperFixSheet = false
     @State private var showDiskImageFixSheet = false
     @State private var showSecurityPolicyFixSheet = false
+    @State private var showKeychainFixSheet = false
 
     var body: some View {
         GeometryReader { _ in
@@ -423,9 +429,63 @@ struct ContentView: View {
                                     }
                                 }
                                 .padding(.top, 6)
-                                .sheet(isPresented: $showSecurityPolicyFixSheet) {
-                                    SecurityPolicyFixView {
-                                        showSecurityPolicyFixSheet = false
+                            .sheet(isPresented: $showSecurityPolicyFixSheet) {
+                                SecurityPolicyFixView {
+                                    showSecurityPolicyFixSheet = false
+                                }
+                            }
+                            } else if issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text(issue.title)
+                                        .font(.title2)
+                                        .bold()
+                                    ScrollView {
+                                        Text(issue.description)
+                                            .font(.body)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                    .frame(minHeight: 50, maxHeight: 120)
+
+                                    Rectangle()
+                                        .fill(Color.gray.opacity(0.15))
+                                        .frame(height: 150)
+                                        .overlay(
+                                            Text("【图片占位：\\(issue.imageName)】")
+                                                .foregroundColor(.gray)
+                                        )
+
+                                    Divider()
+
+                                    HStack {
+                                        Spacer()
+                                        HStack {
+    Spacer()
+    VStack {
+        Spacer()
+        Button(action: {
+            showKeychainFixSheet = true
+        }) {
+            Text("查看解决方案")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(minWidth: 180)
+        }
+        .padding()
+        .background(Color.accentColor.opacity(0.12))
+        .cornerRadius(10)
+        Spacer()
+    }
+    Spacer()
+}
+                                        .padding()
+                                        .background(Color.accentColor.opacity(0.1))
+                                        .cornerRadius(8)
+                                        Spacer()
+                                    }
+                                }
+                                .padding(.top, 6)
+                                .sheet(isPresented: $showKeychainFixSheet) {
+                                    KeychainFixView {
+                                        showKeychainFixSheet = false
                                     }
                                 }
                             } else {

--- a/GatekeeperHelper/KeychainFixView.swift
+++ b/GatekeeperHelper/KeychainFixView.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+struct KeychainFixView: View {
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // 标题栏 + 关闭按钮
+            HStack {
+                Text("解决方案：启动软件时一直弹窗输入密码或存储密码/钥匙串")
+                    .font(.title2)
+                    .bold()
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button(action: dismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("这是因为Mac密码/钥匙串功能错误所导致。")
+
+                    Text("解决方式如下：")
+
+                    Text("1.在桌面上点击顶部导航菜单内的“前往”，并按住 Option键，点击打开弹出的“资源库”。\n2.在资源库中找到并打开Keychains文件夹，仔细查找里面有没有相关应用名称的文件/钥匙串。假设遇到问题的软件为B站，就在其中找所有带有“bilibili”字样的文件/钥匙串，将其全部删除后重启电脑即可。\n3.重启后再次打开软件如果提示创建新的钥匙串，则创建即可，不提示就忽略此步骤。")
+
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.1))
+                        .frame(height: 180)
+                        .overlay(
+                            Text("【图片占位】")
+                                .foregroundColor(.gray)
+                        )
+                }
+                .font(.body)
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button("打开Keychains文件夹") {
+                    let url = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Keychains")
+                    NSWorkspace.shared.open(url)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 620, minHeight: 460)
+    }
+}


### PR DESCRIPTION
## Summary
- add new issue option for repeated keychain password prompts
- provide instructions and shortcut to open Keychains folder

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896b71d41e48323a091708da64fd6ad