### PR TITLE
Add guidance for Adobe installer error

### DIFF
--- a/GatekeeperHelper/AdobeInstallFixView.swift
+++ b/GatekeeperHelper/AdobeInstallFixView.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftUI
+import AppKit
+
+struct AdobeInstallFixView: View {
+    var dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("解决方案：安装Adobe软件时报错")
+                    .font(.title2)
+                    .bold()
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button(action: dismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("这可能是因为Install文件包内的Unix可执行文件错误所致。")
+
+                    Text("解决方式如下：")
+
+                    Text("1. 打开用于安装Adobe软件的磁盘映像（dmg）或安装包，找到“Install”文件，选中并右击选择“显示包内容”。\n2. 在包内沿Contents-MacOS找到Install的Unix可执行文件并双击。\n3. 之后就可以正常执行安装了。")
+
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.1))
+                        .frame(height: 180)
+                        .overlay(
+                            Text("【图片占位】")
+                                .foregroundColor(.gray)
+                        )
+                }
+                .font(.body)
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button("打开访达") {
+                    let url = URL(fileURLWithPath: "/Applications")
+                    NSWorkspace.shared.open(url)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 620, minHeight: 460)
+    }
+}

--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -79,6 +79,11 @@ let knownIssues: [UnlockIssue] = [
         title: "启动软件时一直弹窗输入密码或存储密码/钥匙串",
         description: "有些时候mac OS的“密码/钥匙串”功能会出现崩溃或报错，而导致启动某些App时频繁弹窗提示存储钥匙串，大多数情况下进入访达清空对应软件的钥匙串文件就可解决这一问题。",
         imageName: "issue11-placeholder",
+    ),
+    UnlockIssue(
+        title: "安装Adobe软件时运行Install 文件后报错",
+        description: "当你下载好Adobe家族的软件准备安装而点击dmg或安装包内的“Install”文件时，出现“Error”“The installation cannot continue as the installer file may be damaged. Download the installer file again.”报错时可以尝试下面方法。",
+        imageName: "issue12-placeholder",
     )
 ]
 
@@ -98,6 +103,7 @@ struct ContentView: View {
     @State private var showDiskImageFixSheet = false
     @State private var showSecurityPolicyFixSheet = false
     @State private var showKeychainFixSheet = false
+    @State private var showAdobeInstallFixSheet = false
 
     var body: some View {
         GeometryReader { _ in
@@ -486,6 +492,60 @@ struct ContentView: View {
                                 .sheet(isPresented: $showKeychainFixSheet) {
                                     KeychainFixView {
                                         showKeychainFixSheet = false
+                                    }
+                                }
+                            } else if issue.title == "安装Adobe软件时运行Install 文件后报错" {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text(issue.title)
+                                        .font(.title2)
+                                        .bold()
+                                    ScrollView {
+                                        Text(issue.description)
+                                            .font(.body)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                    .frame(minHeight: 50, maxHeight: 120)
+
+                                    Rectangle()
+                                        .fill(Color.gray.opacity(0.15))
+                                        .frame(height: 150)
+                                        .overlay(
+                                            Text("【图片占位：\(issue.imageName)】")
+                                                .foregroundColor(.gray)
+                                        )
+
+                                    Divider()
+
+                                    HStack {
+                                        Spacer()
+                                        HStack {
+    Spacer()
+    VStack {
+        Spacer()
+        Button(action: {
+            showAdobeInstallFixSheet = true
+        }) {
+            Text("查看解决方案")
+                .font(.system(size: 16, weight: .semibold))
+                .frame(minWidth: 180)
+        }
+        .padding()
+        .background(Color.accentColor.opacity(0.12))
+        .cornerRadius(10)
+        Spacer()
+    }
+    Spacer()
+}
+                                        .padding()
+                                        .background(Color.accentColor.opacity(0.1))
+                                        .cornerRadius(8)
+                                        Spacer()
+                                    }
+                                }
+                                .padding(.top, 6)
+                                .sheet(isPresented: $showAdobeInstallFixSheet) {
+                                    AdobeInstallFixView {
+                                        showAdobeInstallFixSheet = false
                                     }
                                 }
                             } else {


### PR DESCRIPTION
## Summary
- add new Adobe installer error option to app startup problems list
- provide guided instructions for fixing the error with a Finder shortcut

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896cfe8aff88323bb85a8d753ebecef