### PR TITLE
Add command file permission fix option

### DIFF
--- a/GatekeeperHelper/AppPicker.swift
+++ b/GatekeeperHelper/AppPicker.swift
@@ -7,14 +7,19 @@
 
 import Foundation
 import AppKit
+import UniformTypeIdentifiers
 
 struct AppPicker {
-    static func chooseApp() -> URL? {
+    static func chooseApp(allowedExtensions: [String] = ["app"]) -> URL? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.application]
+        if #available(macOS 11.0, *) {
+            panel.allowedContentTypes = allowedExtensions.compactMap { UTType(filenameExtension: $0) }
+        } else {
+            panel.allowedFileTypes = allowedExtensions
+        }
 
         if panel.runModal() == .OK {
             return panel.url

--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -84,6 +84,11 @@ let knownIssues: [UnlockIssue] = [
         title: "安装Adobe软件时运行Install 文件后报错",
         description: "当你下载完毕Adobe家族的软件，准备安装而点击dmg（或安装包）内的“Install”文件时，出现“Error”“The installation cannot continue as the installer file may be damaged. Download the installer file again.”的报错时可以尝试下面方法。",
         imageName: "issue12-placeholder",
+    ),
+    UnlockIssue(
+        title: "文件\"xxx.command\"无法执行，因为您没有正确的访问权限",
+        description: "当你初次运行一个.command文件时，可能会出现访问权限不足而无法正常执行的情况，这种情况通过指令授予其执行权限就可以解决。",
+        imageName: "issue13-placeholder",
     )
 ]
 
@@ -593,7 +598,7 @@ struct ContentView: View {
                                         .padding(.vertical, 2)
                                     }
 
-                                    DropAreaView { url in
+                                    DropAreaView(allowedExtensions: selectedIssue?.title == "文件\"xxx.command\"无法执行，因为您没有正确的访问权限" ? ["command"] : ["app"]) { url in
                                         selectedAppURL = url
                                     }
                                     .frame(height: 180)

--- a/GatekeeperHelper/DropAreaView.swift
+++ b/GatekeeperHelper/DropAreaView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct DropAreaView: View {
+    var allowedExtensions: [String] = ["app"]
     var onAppPicked: (URL) -> Void
 
     var body: some View {
@@ -31,7 +32,7 @@ struct DropAreaView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture {
-            if let url = AppPicker.chooseApp() {
+            if let url = AppPicker.chooseApp(allowedExtensions: allowedExtensions) {
                 onAppPicked(url)
             }
         }
@@ -39,7 +40,7 @@ struct DropAreaView: View {
             providers.first?.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
                 guard let data = item as? Data,
                       let url = URL(dataRepresentation: data, relativeTo: nil),
-                      url.pathExtension == "app" else { return }
+                      allowedExtensions.contains(url.pathExtension.lowercased()) else { return }
                 DispatchQueue.main.async {
                     onAppPicked(url)
                 }

--- a/GatekeeperHelper/FixAppModalView.swift
+++ b/GatekeeperHelper/FixAppModalView.swift
@@ -33,7 +33,7 @@ struct FixAppModalView: View {
                     .padding(.bottom, 4)
             }
 
-            Text("已选择 App")
+            Text(appURL.pathExtension.lowercased() == "command" ? "已选择文件" : "已选择 App")
                 .font(.headline)
 
             Text(appURL.path)
@@ -146,6 +146,12 @@ struct FixAppModalView: View {
                 // ---------------------------
                 case "“xxx软件打开失败”":
                     Unlocker.chmodFixExecutable(in: appURL)
+
+                // ---------------------------
+                // 第十三类问题：command 无法执行
+                // ---------------------------
+                case "文件\"xxx.command\"无法执行，因为您没有正确的访问权限":
+                    Unlocker.chmodCommand(at: appURL)
 
                 default:
                     break

--- a/GatekeeperHelper/Unlocker.swift
+++ b/GatekeeperHelper/Unlocker.swift
@@ -231,6 +231,29 @@ struct Unlocker {
         }
     }
 
+    // MARK: - 第十三个问题：command 文件无执行权限
+    static func chmodCommand(at url: URL) {
+        let path = url.path
+        let command = "/bin/chmod +x \"\(path)\""
+        _ = AuthorizationBridge.run(command: command)
+
+        RepairHistoryManager.shared.addRecord(
+            appName: url.lastPathComponent,
+            method: "chmod_command",
+            success: true
+        )
+
+        let alert = NSAlert()
+        alert.messageText = "执行修复成功"
+        alert.informativeText = "已给予.command文件正确的执行权限，你可尝试重新运行。\n若仍然没有正确的执行权限，你可拷贝该指令进入终端手动执行：\n\(command)"
+        alert.addButton(withTitle: "好")
+        alert.addButton(withTitle: "拷贝指令")
+        let response = alert.runModal()
+        if response == .alertSecondButtonReturn {
+            copyToPasteboard(command)
+        }
+    }
+
     // MARK: - 状态判断工具
 
     /// Gatekeeper 是否开启（“任何来源”已取消）


### PR DESCRIPTION
## Summary
- expand known issues with command file execution rights problem
- allow drop area and picker to accept `.command` files
- add fix flow that runs `chmod +x` on dropped command files and records success

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd7aea6c83238f187ca5cf40e43c