### PR TITLE
feat: add preferences

### DIFF
--- a/GatekeeperHelper/AppSettings.swift
+++ b/GatekeeperHelper/AppSettings.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import ServiceManagement
+
+enum ThemeMode: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .system: return "跟随系统"
+        case .light: return "浅色"
+        case .dark: return "深色"
+        }
+    }
+}
+
+struct AppSettings {
+    static func applyLaunchAtLogin(_ enabled: Bool) {
+        if #available(macOS 13.0, *) {
+            do {
+                if enabled {
+                    try SMAppService.mainApp.register()
+                } else {
+                    SMAppService.mainApp.unregister()
+                }
+            } catch {
+                print("Failed to update launch at login: \(error)")
+            }
+        } else {
+            SMLoginItemSetEnabled(Bundle.main.bundleIdentifier! as CFString, enabled)
+        }
+    }
+
+    static func reset() {
+        if let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+            UserDefaults.standard.synchronize()
+        }
+        applyLaunchAtLogin(false)
+    }
+}
+

--- a/GatekeeperHelper/GatekeeperHelperApp.swift
+++ b/GatekeeperHelper/GatekeeperHelperApp.swift
@@ -3,17 +3,32 @@ import SwiftUI
 @main
 struct GatekeeperHelperApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @AppStorage("themeMode") private var themeMode = ThemeMode.system.rawValue
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .frame(minWidth: 1020, minHeight: 580) // ✅ 正确：作用于 ContentView，而不是 WindowGroup
+                .frame(minWidth: 1020, minHeight: 580)
+                .preferredColorScheme(currentColorScheme)
         }
-        .defaultSize(width: 1120, height: 660) // ✅ 默认打开窗口尺寸
+        .defaultSize(width: 1120, height: 660)
         .windowStyle(DefaultWindowStyle())
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("偏好设置…") {
+                    NSApp.sendAction(#selector(AppDelegate.showPreferencesWindow(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut(",", modifiers: [.command])
+            }
+        }
+    }
 
-        Settings {
-            SettingsView()
+    private var currentColorScheme: ColorScheme? {
+        switch ThemeMode(rawValue: themeMode) ?? .system {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
         }
     }
 }
+

--- a/GatekeeperHelper/SettingsView.swift
+++ b/GatekeeperHelper/SettingsView.swift
@@ -5,22 +5,53 @@
 //  Created by 唐梓耀 on 2025/7/27.
 //
 
-import Foundation
-// SettingsView.swift
 import SwiftUI
 
 struct SettingsView: View {
+    @AppStorage("launchAtLogin") private var launchAtLogin = false
+    @AppStorage("themeMode") private var themeMode = ThemeMode.system.rawValue
+    @AppStorage("escToQuit") private var escToQuit = false
+    @AppStorage("quitWhenLastWindowClosed") private var quitWhenLastWindowClosed = true
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             Text("偏好设置")
                 .font(.title2)
                 .bold()
             Divider()
-            Text("这里是 GatekeeperHelper 的设置内容（待补充）")
-                .foregroundColor(.secondary)
+
+            Toggle("开机自启动", isOn: $launchAtLogin)
+                .onChange(of: launchAtLogin) { value in
+                    AppSettings.applyLaunchAtLogin(value)
+                }
+
+            HStack {
+                Text("主题模式")
+                Picker("主题模式", selection: $themeMode) {
+                    ForEach(ThemeMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode.rawValue)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .frame(maxWidth: 220)
+            }
+
+            Toggle("按 Esc 键退出 GatekeeperHelper", isOn: $escToQuit)
+            Toggle("关闭最后一个窗口时退出 GatekeeperHelper", isOn: $quitWhenLastWindowClosed)
+
             Spacer()
+
+            Button("恢复默认设置") {
+                AppSettings.reset()
+                launchAtLogin = false
+                themeMode = ThemeMode.system.rawValue
+                escToQuit = false
+                quitWhenLastWindowClosed = true
+            }
+            .padding(.bottom, 8)
         }
-        .padding()
-        .frame(minWidth: 400, minHeight: 240)
+        .padding(24)
+        .frame(width: 480, height: 320, alignment: .topLeading)
     }
 }
+


### PR DESCRIPTION
## Summary
- add preferences window with launch at login, theme mode, escape & window closing options
- support resetting preferences to defaults and apply theme globally
- unify settings access through a single window

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6896fe261bf4832396cb670edcf0ecd8