### PR TITLE
Add attribution footer to detail pages

### DIFF
--- a/GatekeeperHelper/AdobeInstallFixView.swift
+++ b/GatekeeperHelper/AdobeInstallFixView.swift
@@ -56,6 +56,12 @@ struct AdobeInstallFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/AppStoreFixView.swift
+++ b/GatekeeperHelper/AppStoreFixView.swift
@@ -58,6 +58,12 @@ struct AppStoreFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -642,6 +642,13 @@ struct ContentView: View {
                         }
                         .padding(.trailing, 12)
                         .padding(.bottom, 12)
+
+                        Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                            .font(.footnote)
+                            .foregroundColor(.gray)
+                            .lineLimit(1)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.bottom, 12)
                     }
                     .padding()
                 }

--- a/GatekeeperHelper/DiskImageFixView.swift
+++ b/GatekeeperHelper/DiskImageFixView.swift
@@ -56,6 +56,12 @@ struct DiskImageFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/KeychainFixView.swift
+++ b/GatekeeperHelper/KeychainFixView.swift
@@ -57,6 +57,12 @@ struct KeychainFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/MalwareCheckFixView.swift
+++ b/GatekeeperHelper/MalwareCheckFixView.swift
@@ -66,6 +66,12 @@ struct MalwareCheckFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/SecurityPolicyFixView.swift
+++ b/GatekeeperHelper/SecurityPolicyFixView.swift
@@ -53,6 +53,12 @@ struct SecurityPolicyFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/UnverifiedDeveloperFixView.swift
+++ b/GatekeeperHelper/UnverifiedDeveloperFixView.swift
@@ -57,6 +57,12 @@ struct UnverifiedDeveloperFixView: View {
                 }
                 .keyboardShortcut(.defaultAction)
             }
+
+            Text("部分信息与素材转载至https://foxirj.com，GatekeeperHelper开源免费，仅供学习交流，侵权请联系删除。")
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)


### PR DESCRIPTION
## Summary
- add grey attribution footer to right-side detail pages
- include same attribution on all solution views

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898176083ec832385d40fc8d6620475