### PR TITLE
Refine UI alignment and settings

### DIFF
--- a/GatekeeperHelper/AdobeInstallFixView.swift
+++ b/GatekeeperHelper/AdobeInstallFixView.swift
@@ -61,7 +61,8 @@ struct AdobeInstallFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/AppStoreFixView.swift
+++ b/GatekeeperHelper/AppStoreFixView.swift
@@ -63,7 +63,8 @@ struct AppStoreFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -647,11 +647,14 @@ struct ContentView: View {
                             .font(.footnote)
                             .foregroundColor(.gray)
                             .lineLimit(1)
-                            .frame(maxWidth: .infinity, alignment: .center)
+                            .multilineTextAlignment(.trailing)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                             .padding(.bottom, 12)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(minWidth: 960, minHeight: 640)
         }

--- a/GatekeeperHelper/DiskImageFixView.swift
+++ b/GatekeeperHelper/DiskImageFixView.swift
@@ -61,7 +61,8 @@ struct DiskImageFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/KeychainFixView.swift
+++ b/GatekeeperHelper/KeychainFixView.swift
@@ -62,7 +62,8 @@ struct KeychainFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/MalwareCheckFixView.swift
+++ b/GatekeeperHelper/MalwareCheckFixView.swift
@@ -71,7 +71,8 @@ struct MalwareCheckFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/SecurityPolicyFixView.swift
+++ b/GatekeeperHelper/SecurityPolicyFixView.swift
@@ -58,7 +58,8 @@ struct SecurityPolicyFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)

--- a/GatekeeperHelper/SettingsView.swift
+++ b/GatekeeperHelper/SettingsView.swift
@@ -32,11 +32,12 @@ struct SettingsView: View {
 
             HStack {
                 Text("主题模式")
-                Picker("主题模式", selection: $themeMode) {
+                Picker("", selection: $themeMode) {
                     ForEach(ThemeMode.allCases) { mode in
                         Text(mode.displayName).tag(mode.rawValue)
                     }
                 }
+                .labelsHidden()
                 .pickerStyle(SegmentedPickerStyle())
                 .frame(maxWidth: 220)
             }

--- a/GatekeeperHelper/UnverifiedDeveloperFixView.swift
+++ b/GatekeeperHelper/UnverifiedDeveloperFixView.swift
@@ -62,7 +62,8 @@ struct UnverifiedDeveloperFixView: View {
                 .font(.footnote)
                 .foregroundColor(.gray)
                 .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .center)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(20)
         .frame(minWidth: 620, minHeight: 460)


### PR DESCRIPTION
## Summary
- align attribution disclaimers to the right across fix views for consistent look
- expand issue list layout to keep header aligned when selecting the first question
- deduplicate "主题模式" label in settings to avoid repeated text

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68981aed24d08323900c9231ae95439f