### PR TITLE
Correct issue image mapping and adjust layout

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -43,32 +43,32 @@ let knownIssues: [UnlockIssue] = [
     UnlockIssue(
         title: "应用程序XXX无法打开",
         description: "macOS 的安全机制针对某些第三方 App 是“带壳”的，此时这些软件将提示“应用程序\"xxx\"无法打开”。通过引入第三方工具进行脱壳操作即可正常打开。",
-        imageName: "issue5",
+        imageName: "issue4",
     ),
     UnlockIssue(
         title: "文件XXX.command无法执行，因为您没有正确的访问权限",
         description: "当你初次运行一个.command文件时，可能会出现访问权限不足而无法正常执行的情况，这种情况通过指令授予其执行权限就可以解决。",
-        imageName: "issue13",
+        imageName: "issue5",
     ),
     UnlockIssue(
         title: "无法打开XXX，因为 Apple 无法检查其是否包含恶意软件",
         description: "由于在 Apple 中引入了对应用程序进行公证的强制性措施，macOS Catalina 及以上版本系统不允许您运行未经验证的应用程序，即使该应用程序已经添加开发者签名也是如此。这会导致应用程序无法运行。",
-        imageName: "issue4",
+        imageName: "issue6",
     ),
     UnlockIssue(
         title: "Apple无法验证XXX是否包含可能危害 Mac 安全或泄漏隐私的恶意软件",
         description: "此问题是“无法打开“xxx”，因为 Apple 无法检查其是否包含恶意软件”的另一种表述。macOS Catalina 及更高版本要求App 必须通过 Apple 的公证（Notarization）验证，未通过验证会提示类似此警告，解决方法与前者相同。",
-        imageName: "issue8",
+        imageName: "issue7",
     ),
     UnlockIssue(
         title: "无法打开XXX，因为它不是从 App Store下载",
         description: "如果 Mac 是全新的或从未更改过软件安装安全性设置，其默认设置是仅允许安装来自「App Store 」的软件。而你正在安装的软件是从浏览器或其他第三方下载的时，就会看到这一警告信息。",
-        imageName: "issue6",
+        imageName: "issue8",
     ),
     UnlockIssue(
         title: "无法打开XXX，因为无法验证开发者",
         description: "即便你的Mac已经允许安装App Store和已知开发者的应用，但当你尝试安装的某些App时，可能也还会看到此类警告。",
-        imageName: "issue7",
+        imageName: "issue9",
     ),
     UnlockIssue(
         title: "无法打开XXX，因为“安全策略”已设为“某某安全性”",
@@ -78,17 +78,17 @@ let knownIssues: [UnlockIssue] = [
     UnlockIssue(
         title: "未能打开磁盘映像。磁盘映像格式已过时。请使用命令行工具“hdiutil”将其转换为新格式",
         description: "此问题常出现在版本较旧的macOS中，通常来说问题并不出在磁盘映像本身，通过系统自带的“磁盘工具”应用程序打开此磁盘映像即可。",
-        imageName: "issue9",
+        imageName: "issue11",
     ),
     UnlockIssue(
         title: "启动软件时一直弹窗输入密码或存储密码/钥匙串",
         description: "有些时候macOS的“密码/钥匙串”功能会出现崩溃或报错，而导致启动某些App时频繁弹窗提示存储钥匙串，大多数情况下进入访达清空对应软件的钥匙串文件就可解决这一问题。",
-        imageName: "issue11",
+        imageName: "issue12",
     ),
     UnlockIssue(
         title: "安装 Adobe软件时运行 Install文件后报错",
         description: "当你下载完毕Adobe家族的软件，准备安装而点击dmg（或安装包）内的“Install”文件时，出现“Error”“The installation cannot continue as the installer file may be damaged. Download the installer file again.”的报错时可以尝试下面方法。",
-        imageName: "issue12",
+        imageName: "issue13",
     ),
 ]
 
@@ -174,7 +174,7 @@ struct ContentView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         if let issue = selectedIssue {
                             if issue.title == "无法打开XXX，因为 Apple 无法检查其是否包含恶意软件" || issue.title == "Apple无法验证XXX是否包含可能危害 Mac 安全或泄漏隐私的恶意软件" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -183,12 +183,12 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
                                     Image(issue.imageName)
                                         .resizable()
                                         .scaledToFit()
-                                        .frame(height: 170)
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
                                         .frame(maxWidth: .infinity)
 
                                     Divider()
@@ -229,7 +229,7 @@ struct ContentView: View {
                                     }
                                 }
                             } else if issue.title == "无法打开XXX，因为它不是从 App Store下载" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -238,13 +238,13 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
-                                      Image(issue.imageName)
-                                      .resizable()
-                                      .scaledToFit()
-                                      .frame(height: 170)
-                                      .frame(maxWidth: .infinity)
+                                    Image(issue.imageName)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
+                                        .frame(maxWidth: .infinity)
 
                                     Divider()
 
@@ -281,7 +281,7 @@ struct ContentView: View {
                                     }
                                 }
                             } else if issue.title == "无法打开XXX，因为无法验证开发者" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -290,12 +290,12 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
                                     Image(issue.imageName)
                                         .resizable()
                                         .scaledToFit()
-                                        .frame(height: 170)
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
                                         .frame(maxWidth: .infinity)
 
                                     Divider()
@@ -333,7 +333,7 @@ struct ContentView: View {
                                     }
                                 }
                             } else if issue.title == "未能打开磁盘映像。磁盘映像格式已过时。请使用命令行工具“hdiutil”将其转换为新格式" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -342,13 +342,13 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
-                                      Image(issue.imageName)
-                                          .resizable()
-                                          .scaledToFit()
-                                          .frame(height: 170)
-                                          .frame(maxWidth: .infinity)
+                                    Image(issue.imageName)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
+                                        .frame(maxWidth: .infinity)
 
                                     Divider()
 
@@ -385,7 +385,7 @@ struct ContentView: View {
                                 }
                             }
                             } else if issue.title == "无法打开XXX，因为“安全策略”已设为“某某安全性”" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -394,13 +394,13 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
-                                      Image(issue.imageName)
-                                          .resizable()
-                                          .scaledToFit()
-                                          .frame(height: 170)
-                                          .frame(maxWidth: .infinity)
+                                    Image(issue.imageName)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
+                                        .frame(maxWidth: .infinity)
 
                                     Divider()
 
@@ -437,7 +437,7 @@ struct ContentView: View {
                                 }
                             }
                             } else if issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -446,12 +446,12 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
                                     Image(issue.imageName)
                                         .resizable()
                                         .scaledToFit()
-                                        .frame(height: 170)
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
                                         .frame(maxWidth: .infinity)
 
                                     Divider()
@@ -489,7 +489,7 @@ struct ContentView: View {
                                     }
                                 }
                             } else if issue.title == "安装 Adobe软件时运行 Install文件后报错" {
-                                VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -498,13 +498,13 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
-                                      Image(issue.imageName)
-                                          .resizable()
-                                          .scaledToFit()
-                                          .frame(height: 170)
-                                          .frame(maxWidth: .infinity)
+                                    Image(issue.imageName)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
+                                        .frame(maxWidth: .infinity)
 
                                     Divider()
 
@@ -541,7 +541,7 @@ struct ContentView: View {
                                     }
                                 }
                             } else {
-                                VStack(alignment: .leading, spacing: 10) {
+                                VStack(alignment: .leading, spacing: 8) {
                                     Text(issue.title)
                                         .font(.title2)
                                         .bold()
@@ -552,13 +552,13 @@ struct ContentView: View {
                                             .font(.body)
                                             .fixedSize(horizontal: false, vertical: true)
                                     }
-                                    .frame(minHeight: 50, maxHeight: 120)
+                                    .frame(maxHeight: 120)
 
-                                      Image(issue.imageName)
-                                          .resizable()
-                                          .scaledToFit()
-                                          .frame(height: issue.title == "应用程序XXX无法打开" ? 150 : 170)
-                                          .frame(maxWidth: .infinity)
+                                    Image(issue.imageName)
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(height: issue.title == "启动软件时一直弹窗输入密码或存储密码/钥匙串" || issue.title == "安装 Adobe软件时运行 Install文件后报错" ? 170 : 220)
+                                        .frame(maxWidth: .infinity)
 
                                     Divider()
 


### PR DESCRIPTION
## Summary
- map issue images to their matching problem options
- enlarge images for the first 11 issues and tighten spacing in detail views

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689861ad76d48323ba5e5b8461783a92