### PR TITLE
Add final imagery to security guidance modals

### DIFF
--- a/GatekeeperHelper/AdobeInstallFixView.swift
+++ b/GatekeeperHelper/AdobeInstallFixView.swift
@@ -34,13 +34,6 @@ struct AdobeInstallFixView: View {
 
                     Text("1. 打开用于安装Adobe软件的磁盘映像（dmg）或安装包，找到“Install”文件，选中并右击选择“显示包内容”。\n2. 在包内「Contents-MacOS」找到Install的Unix可执行文件并双击。\n3. 之后就可以正常执行安装了。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】")
-                                .foregroundColor(.gray)
-                        )
                 }
                 .font(.body)
             }

--- a/GatekeeperHelper/AppStoreFixView.swift
+++ b/GatekeeperHelper/AppStoreFixView.swift
@@ -35,13 +35,11 @@ struct AppStoreFixView: View {
 
                     Text("1. 打开「系统设置」→「隐私与安全性」。\n2. 滚动到底部，在“安全性-允许以下来源的应用程序”处选择“App Store与已知开发者”后输入密码确认修改。\n3. 完成调整后即可运行相应App。\n\n你也可通过本软件第一个App启动问题中的“永久禁用Gatekeeper”功能，获得把该设置改为“任何来源”的权限。否则，Apple出于安全考虑,不会直接展示此选项。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】展示设置中“App Store与已知开发者”选项位置")
-                                .foregroundColor(.gray)
-                        )
+                    Image("detail8")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .cornerRadius(8)
                 }
                 .font(.body)
             }

--- a/GatekeeperHelper/DiskImageFixView.swift
+++ b/GatekeeperHelper/DiskImageFixView.swift
@@ -34,13 +34,11 @@ struct DiskImageFixView: View {
 
                     Text("1. command+空格，搜索“磁盘工具”并打开。\n2. 在顶部导航菜单找到“文件”并点击。\n3. 选择“打开磁盘映像”。\n4. 在访达弹窗中选择报错的磁盘映像（dmg）并点击右下角打开。\n5. 之后就可以通过正常方式打开该磁盘映像，若无效可多次重试，一般多打开几次就可以正常使用该映像。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】")
-                                .foregroundColor(.gray)
-                        )
+                    Image("detail11")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .cornerRadius(8)
                 }
                 .font(.body)
             }

--- a/GatekeeperHelper/KeychainFixView.swift
+++ b/GatekeeperHelper/KeychainFixView.swift
@@ -35,13 +35,11 @@ struct KeychainFixView: View {
 
                     Text("1.在桌面上点击顶部导航菜单内的“前往”，并按住 Option键，点击打开弹出的“资源库”。\n2.在资源库中找到并打开Keychains文件夹，仔细查找里面有没有相关应用名称的文件/钥匙串。假设遇到问题的软件为B站，就在其中找所有带有“bilibili”字样的文件/钥匙串，将其全部删除后重启电脑即可。\n3.重启后再次打开软件如果提示创建新的钥匙串，则创建即可，不提示就忽略此步骤。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】")
-                                .foregroundColor(.gray)
-                        )
+                    Image("detail12")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .cornerRadius(8)
                 }
                 .font(.body)
             }

--- a/GatekeeperHelper/MalwareCheckFixView.swift
+++ b/GatekeeperHelper/MalwareCheckFixView.swift
@@ -43,13 +43,11 @@ struct MalwareCheckFixView: View {
 
                     Text("1. 打开该 App，会看到系统提示框。\n2. 点击“好”关闭提示。\n3. 打开『系统设置』→『隐私与安全性』。\n4. 滚动到底部，在“仍要打开”处点击“允许”。\n5. 输入密码后即可运行该 App。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】展示系统设置中“仍要打开”按钮位置")
-                                .foregroundColor(.gray)
-                        )
+                    Image("detail6and7")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .cornerRadius(8)
                 }
                 .font(.body)
             }

--- a/GatekeeperHelper/UnverifiedDeveloperFixView.swift
+++ b/GatekeeperHelper/UnverifiedDeveloperFixView.swift
@@ -35,13 +35,11 @@ struct UnverifiedDeveloperFixView: View {
 
                     Text("1.右键点击对应App，选择打开，连续操作两次。\n2.再在访达中对应位置找到软件，选中并右击打开。\n3.完成上述以后，之后就可以通过双击打开软件了。")
 
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.1))
-                        .frame(height: 180)
-                        .overlay(
-                            Text("【图片占位】展示访达中打开应用流程")
-                                .foregroundColor(.gray)
-                        )
+                    Image("detail9")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .cornerRadius(8)
                 }
                 .font(.body)
             }


### PR DESCRIPTION
## Summary
- replace placeholder blocks in the malware, App Store, unverified developer, disk image, and keychain fix dialogs with their corresponding asset imagery
- remove the unused image placeholder from the Adobe installer fix modal

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ea132cc8fc8323bd1af55eff95a4cc