### PR TITLE
Fix multiline layout for Gatekeeper restore notice

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -570,6 +570,9 @@ struct ContentView: View {
                                             Text("如果你之前使用过“永久禁用”选项，可一键恢复 Gatekeeper：")
                                                 .font(.callout)
                                                 .foregroundColor(.secondary)
+                                                .multilineTextAlignment(.leading)
+                                                .fixedSize(horizontal: false, vertical: true)
+                                                .layoutPriority(1)
                                             Spacer()
                                             Button("恢复 Gatekeeper") {
                                                 Unlocker.restoreGatekeeper()


### PR DESCRIPTION
## Summary
- allow the Gatekeeper restore helper text to wrap over multiple lines
- ensure the message keeps its leading alignment without clipping other content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea16f3dc948323ad36cac6251629d5