### PR TITLE
Ensure Gatekeeper restore message fills available width

### DIFF
--- a/GatekeeperHelper/ContentView.swift
+++ b/GatekeeperHelper/ContentView.swift
@@ -570,6 +570,10 @@ struct ContentView: View {
                                             Text("如果你之前使用过“永久禁用”选项，可一键恢复 Gatekeeper：")
                                                 .font(.callout)
                                                 .foregroundColor(.secondary)
+                                                .multilineTextAlignment(.leading)
+                                                .fixedSize(horizontal: false, vertical: true)
+                                                .frame(maxWidth: .infinity, alignment: .leading)
+                                                .layoutPriority(1)
                                             Spacer()
                                             Button("恢复 Gatekeeper") {
                                                 Unlocker.restoreGatekeeper()


### PR DESCRIPTION
## Summary
- expand the Gatekeeper restore helper text to occupy the available horizontal space
- keep the helper button layout unchanged while allowing the message to wrap cleanly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea16f3dc948323ad36cac6251629d5