### PR TITLE
Fix NSAlert button appearance on newer macOS

### DIFF
--- a/GatekeeperHelper/FixAppModalView.swift
+++ b/GatekeeperHelper/FixAppModalView.swift
@@ -102,7 +102,7 @@ struct FixAppModalView: View {
                             点击“好”将立即为你打开设置界面。
                             """
                             alert.addButton(withTitle: "好")
-                            alert.runModal()
+                            alert.runModalWithSystemStyle()
 
                             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy") {
                                 NSWorkspace.shared.open(url)

--- a/GatekeeperHelper/NSAlert+SystemStyle.swift
+++ b/GatekeeperHelper/NSAlert+SystemStyle.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+extension NSAlert {
+    private func applySystemButtonStyle() {
+        if #available(macOS 11.0, *) {
+            for (index, button) in buttons.enumerated() {
+                button.isBordered = true
+                button.bezelStyle = .rounded
+                button.controlSize = .large
+                button.keyEquivalent = index == 0 ? "\r" : ""
+                if index == 0 {
+                    button.bezelColor = .controlAccentColor
+                    button.contentTintColor = .white
+                } else {
+                    button.bezelColor = nil
+                    button.contentTintColor = .labelColor
+                }
+            }
+        } else {
+            buttons.first?.keyEquivalent = "\r"
+        }
+    }
+
+    @discardableResult
+    func runModalWithSystemStyle() -> NSApplication.ModalResponse {
+        applySystemButtonStyle()
+        if !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        return runModal()
+    }
+}

--- a/GatekeeperHelper/Unlocker.swift
+++ b/GatekeeperHelper/Unlocker.swift
@@ -253,7 +253,7 @@ struct Unlocker {
             alert.informativeText = "未能给予.command文件正确的执行权限。你可拷贝该指令进入终端手动执行：\n\(command)"
             alert.addButton(withTitle: "好")
             alert.addButton(withTitle: "拷贝指令")
-            let response = alert.runModal()
+            let response = alert.runModalWithSystemStyle()
             if response == .alertSecondButtonReturn {
                 copyToPasteboard(command)
             }
@@ -271,7 +271,7 @@ struct Unlocker {
         alert.informativeText = "已给予.command文件正确的执行权限，你可尝试重新运行。\n若仍然没有正确的执行权限，你可拷贝该指令进入终端手动执行：\n\(command)"
         alert.addButton(withTitle: "好")
         alert.addButton(withTitle: "拷贝指令")
-        let response = alert.runModal()
+        let response = alert.runModalWithSystemStyle()
         if response == .alertSecondButtonReturn {
             copyToPasteboard(command)
         }
@@ -306,7 +306,7 @@ struct Unlocker {
         alert.messageText = title
         alert.informativeText = message
         alert.addButton(withTitle: buttonText)
-        alert.runModal()
+        alert.runModalWithSystemStyle()
     }
 
     static func copyToPasteboard(_ string: String) {


### PR DESCRIPTION
## Summary
- add an AppKit extension that reapplies the system accent styling to NSAlert buttons before presentation
- update existing alert presentations to route through the helper so default buttons regain their blue emphasis on newer macOS releases

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea3b5b70d4832386c0b89cbf9d93d4