### PR TITLE
Adopt macOS 26 rounded window styling

### DIFF
--- a/GatekeeperHelper/AppDelegate.swift
+++ b/GatekeeperHelper/AppDelegate.swift
@@ -99,6 +99,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.center()
         window.title = "偏好设置"
         window.isReleasedWhenClosed = false
+        RoundedWindowStyleModifier.configure(window: window)
         window.contentView = NSHostingView(rootView: SettingsView())
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/GatekeeperHelper/GatekeeperHelperApp.swift
+++ b/GatekeeperHelper/GatekeeperHelperApp.swift
@@ -10,6 +10,7 @@ struct GatekeeperHelperApp: App {
             ContentView()
                 .frame(minWidth: 1020, minHeight: 580)
                 .preferredColorScheme(currentColorScheme)
+                .macOS26RoundedWindowStyle()
         }
         .defaultSize(width: 1120, height: 775)
         .windowStyle(DefaultWindowStyle())

--- a/GatekeeperHelper/RoundedWindowStyleModifier.swift
+++ b/GatekeeperHelper/RoundedWindowStyleModifier.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import AppKit
+
+private struct RoundedWindowConfigurator: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            if let window = view.window {
+                RoundedWindowStyleModifier.configure(window: window)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                RoundedWindowStyleModifier.configure(window: window)
+            }
+        }
+    }
+}
+
+struct RoundedWindowStyleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.background(RoundedWindowConfigurator())
+    }
+
+    static func configure(window: NSWindow) {
+        window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
+        window.isMovableByWindowBackground = true
+        if #available(macOS 11.0, *) {
+            window.toolbarStyle = .expanded
+        }
+        window.invalidateShadow()
+    }
+}
+
+extension View {
+    func macOS26RoundedWindowStyle() -> some View {
+        modifier(RoundedWindowStyleModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable SwiftUI modifier that configures NSWindow instances for the macOS 26 rounded appearance
- apply the rounded window styling to the primary window group and the preferences window

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ea677add648323a31c659584bf280c