### PR TITLE
feat: add GitHub release updater

### DIFF
--- a/GatekeeperHelper/SettingsView.swift
+++ b/GatekeeperHelper/SettingsView.swift
@@ -14,49 +14,54 @@ struct SettingsView: View {
     @AppStorage("quitWhenLastWindowClosed") private var quitWhenLastWindowClosed = true
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text("偏好设置")
-                .font(.title2)
-                .bold()
-            Divider()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("偏好设置")
+                        .font(.title2)
+                        .bold()
+                    Divider()
 
-            Toggle("开机自启动", isOn: $launchAtLogin)
-                .onChange(of: launchAtLogin) { value in
-                    AppSettings.applyLaunchAtLogin(value)
-                }
+                    Toggle("开机自启动", isOn: $launchAtLogin)
+                        .onChange(of: launchAtLogin) { value in
+                            AppSettings.applyLaunchAtLogin(value)
+                        }
 
-            Text("⚠️ 可能仅在 macOS 13 及以上系统生效")
-                .font(.caption)
-                .foregroundColor(.gray)
-                .padding(.leading, 4)
+                    Text("⚠️ 可能仅在 macOS 13 及以上系统生效")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                        .padding(.leading, 4)
 
-            HStack {
-                Text("主题模式")
-                Picker("", selection: $themeMode) {
-                    ForEach(ThemeMode.allCases) { mode in
-                        Text(mode.displayName).tag(mode.rawValue)
+                    HStack {
+                        Text("主题模式")
+                        Picker("", selection: $themeMode) {
+                            ForEach(ThemeMode.allCases) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(SegmentedPickerStyle())
+                        .frame(maxWidth: 220)
                     }
+
+                    Toggle("按 Esc 键退出 GatekeeperHelper", isOn: $escToQuit)
+                    Toggle("关闭最后一个窗口时退出 GatekeeperHelper", isOn: $quitWhenLastWindowClosed)
                 }
-                .labelsHidden()
-                .pickerStyle(SegmentedPickerStyle())
-                .frame(maxWidth: 220)
+
+                UpdateSettingsView()
+
+                Button("恢复默认设置") {
+                    AppSettings.reset()
+                    launchAtLogin = false
+                    themeMode = ThemeMode.system.rawValue
+                    escToQuit = false
+                    quitWhenLastWindowClosed = true
+                    UpdatePreferences().reset()
+                }
+                .padding(.bottom, 8)
             }
-
-            Toggle("按 Esc 键退出 GatekeeperHelper", isOn: $escToQuit)
-            Toggle("关闭最后一个窗口时退出 GatekeeperHelper", isOn: $quitWhenLastWindowClosed)
-
-            Spacer()
-
-            Button("恢复默认设置") {
-                AppSettings.reset()
-                launchAtLogin = false
-                themeMode = ThemeMode.system.rawValue
-                escToQuit = false
-                quitWhenLastWindowClosed = true
-            }
-            .padding(.bottom, 8)
+            .padding(24)
         }
-        .padding(24)
-        .frame(width: 480, height: 350, alignment: .topLeading)
+        .frame(width: 520, height: 520, alignment: .topLeading)
     }
 }

--- a/LaunchAgents/com.gkh.updater.plist.template
+++ b/LaunchAgents/com.gkh.updater.plist.template
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.gkh.updater</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Applications/GatekeeperHelper.app/Contents/MacOS/GKHCLIUpdater</string>
+    <string>--check</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer><HOUR></integer>
+    <key>Minute</key><integer><MINUTE></integer>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>~/Library/Logs/gkh_updater.out</string>
+  <key>StandardErrorPath</key><string>~/Library/Logs/gkh_updater.err</string>
+</dict></plist>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# GatekeeperHelper 更新机制说明
+
+GatekeeperHelper 通过 GitHub Releases 提供自更新能力，包括检查、下载、校验与自动替换应用。主要特性：
+
+- 在偏好设置中手动或自动检查更新，可选择是否包含预发布版本。
+- 支持运行期自动轮询与可选 LaunchAgent（即使主程序未运行也可定时检查）。
+- 下载完成后执行 SHA-256 校验，并在用户授权下移除隔离属性，尽可能减少 Gatekeeper 阻拦。
+- 由独立的 `UpdaterHelper` 进程负责备份旧版、替换新版本与重启应用，若失败会尝试回滚并记录日志。
+- 所有更新日志与故障信息统一写入 `~/Library/Logs/GatekeeperHelper/Updater.log`，可在 UI 中一键复制或定位。
+
+## 发布流程
+
+1. 执行 `Scripts/release_build.sh <版本号>` 生成 `GatekeeperHelper-<版本号>.zip` 与 `checksums.txt`。
+2. 在 GitHub 创建 Tag（格式 `vX.Y.Z`）并发布 Release，上传生成的压缩包与校验文件，填入更新日志。
+3. 预发布版本请勾选 **Pre-release**，主程序可通过“包含 Beta 版本”开关订阅。
+4. 发布后使用旧版本的 GatekeeperHelper 点击“检查更新”，验证完整链路。
+
+## 常见问题
+
+- **Gatekeeper 阻止启动**：参考 `Resources/Privacy/GatekeeperGuide.md`，或在偏好设置中允许更新器自动移除隔离属性。
+- **GitHub 限流**：若频繁请求 API 导致 403，可在系统钥匙串添加个人访问令牌并扩展 `GitHubAPIClient` 的 `tokenProvider`。
+- **失败排查**：在设置页点击“复制最近日志”或“打开日志文件夹”，将日志附在 Issue 中反馈。
+
+更多开发细节与后续规划见 `Resources/Privacy/GatekeeperGuide.md` 与源代码注释。

--- a/Resources/Privacy/GatekeeperGuide.md
+++ b/Resources/Privacy/GatekeeperGuide.md
@@ -1,0 +1,10 @@
+# Gatekeeper 放行指南
+
+由于 GatekeeperHelper 目前未使用 Apple Developer 证书签名，第一次运行或每次自动更新后，macOS 可能弹出 “无法验证开发者” 的提示。您可以按照以下任意方式放行：
+
+1. 在 Finder 中找到 `GatekeeperHelper.app`，按住 `Control` 键并点击图标，选择 **打开**，随后在弹出的提示框中再次点击 **打开**。
+2. 打开 **系统设置 → 隐私与安全性**，在“安全性”部分看到 “来自开发者 Tang1206cc 的 `GatekeeperHelper.app` 已被阻止使用”，点击 **仍要打开**。
+
+勾选偏好设置中的“允许更新器在安装后移除 Gatekeeper 隔离属性”选项后，更新器将在安装完成后为您执行 `xattr -d com.apple.quarantine`，仅作用于 GatekeeperHelper 的应用包，可减少重复出现的提醒。请在理解风险并确认来源可信的前提下启用该选项。
+
+如遇问题，欢迎在 [GitHub Issues](https://github.com/Tang1206cc/GatekeeperHelper/issues) 中反馈，并附上 `~/Library/Logs/GatekeeperHelper/Updater.log` 日志的最近内容以便排查。

--- a/Scripts/local_test_update.sh
+++ b/Scripts/local_test_update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BUNDLE="GatekeeperHelper.app"
+TEMP_DIR="$(mktemp -d /tmp/gkh-update-test.XXXXXX)"
+ZIP_PATH="$TEMP_DIR/test.zip"
+
+function cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+  echo "请在包含 GatekeeperHelper.app 的目录执行。" >&2
+  exit 1
+fi
+
+/usr/bin/zip -ry "$ZIP_PATH" "$APP_BUNDLE"
+SHA=$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')
+cat <<EOT > "$TEMP_DIR/checksums.txt"
+SHA256 $SHA $(basename "$ZIP_PATH")
+EOT
+
+echo "已在 $TEMP_DIR 生成测试包，可模拟 GitHub Releases 进行端到端测试。"

--- a/Scripts/release_build.sh
+++ b/Scripts/release_build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "用法: $0 <version>" >&2
+  exit 1
+fi
+
+APP="GatekeeperHelper.app"
+VER="$1"
+OUT="GatekeeperHelper-${VER}.zip"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -d "$APP" ]]; then
+  echo "未找到 $APP，请先构建发布版本。" >&2
+  exit 1
+fi
+
+rm -f "$OUT"
+/usr/bin/zip -ry "$OUT" "$APP"
+SHA=$(shasum -a 256 "$OUT" | awk '{print $1}')
+cat <<EOT > checksums.txt
+SHA256 $SHA $OUT
+EOT
+
+echo "Built $OUT with SHA256=$SHA"

--- a/Sources/App/Services/Checksum.swift
+++ b/Sources/App/Services/Checksum.swift
@@ -1,0 +1,40 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import CommonCrypto
+#endif
+
+public enum Checksum {
+    public static func sha256(for fileURL: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+#if canImport(CryptoKit)
+        var hasher = SHA256()
+        while autoreleasepool(invoking: {
+            let data = handle.readData(ofLength: 1024 * 512)
+            if data.isEmpty { return false }
+            hasher.update(data: data)
+            return true
+        }) {}
+        let digest = hasher.finalize()
+        return digest.map { String(format: "%02x", $0) }.joined()
+#else
+        let data = handle.readDataToEndOfFile()
+        return sha256Fallback(data: data)
+#endif
+    }
+
+#if !canImport(CryptoKit)
+    private static func sha256Fallback(data: Data) -> String {
+        var context = CC_SHA256_CTX()
+        CC_SHA256_Init(&context)
+        data.withUnsafeBytes { buffer in
+            _ = CC_SHA256_Update(&context, buffer.baseAddress, CC_LONG(buffer.count))
+        }
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        CC_SHA256_Final(&digest, &context)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+#endif
+}

--- a/Sources/App/Services/GitHubAPI.swift
+++ b/Sources/App/Services/GitHubAPI.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+public struct GHAsset: Decodable, Sendable {
+    public let name: String
+    public let browserDownloadURL: URL
+    public let size: Int
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case browserDownloadURL = "browser_download_url"
+        case size
+    }
+}
+
+public struct GHRelease: Decodable, Sendable {
+    public let tagName: String
+    public let prerelease: Bool
+    public let assets: [GHAsset]
+    public let body: String?
+    public let publishedAt: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case prerelease
+        case assets
+        case body
+        case publishedAt = "published_at"
+    }
+}
+
+public enum GHError: Error, LocalizedError {
+    case rateLimited
+    case network(status: Int)
+    case parse
+    case noAsset
+    case checksumMissing
+
+    public var errorDescription: String? {
+        switch self {
+        case .rateLimited:
+            return "GitHub API 请求已达未认证配额，请稍后再试或提供 Token。"
+        case .network(let status):
+            return "GitHub API 请求失败，状态码 \(status)。"
+        case .parse:
+            return "无法解析 GitHub Release 数据。"
+        case .noAsset:
+            return "最新 Release 中缺少可用的更新资产。"
+        case .checksumMissing:
+            return "未找到用于校验的 SHA-256 值。"
+        }
+    }
+}
+
+public protocol GitHubAPI: Sendable {
+    func latestRelease(includePrereleases: Bool) async throws -> GHRelease
+    func fetchChecksums(from release: GHRelease) async throws -> [String: String]
+}
+
+public actor GitHubAPIClient: GitHubAPI {
+    public enum Source {
+        case stable
+        case all
+    }
+
+    private let owner: String
+    private let repo: String
+    private let tokenProvider: () -> String?
+    private let session: URLSession
+
+    public init(owner: String, repo: String, tokenProvider: @escaping () -> String? = { nil }) {
+        self.owner = owner
+        self.repo = repo
+        self.tokenProvider = tokenProvider
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 60
+        self.session = URLSession(configuration: configuration)
+    }
+
+    public func latestRelease(includePrereleases: Bool) async throws -> GHRelease {
+        let url = includePrereleases
+            ? URL(string: "https://api.github.com/repos/\(owner)/\(repo)/releases")!
+            : URL(string: "https://api.github.com/repos/\(owner)/\(repo)/releases/latest")!
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("GatekeeperHelper-Updater", forHTTPHeaderField: "User-Agent")
+        if let token = tokenProvider() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GHError.network(status: -1)
+        }
+        guard http.statusCode == 200 else {
+            if http.statusCode == 403 { throw GHError.rateLimited }
+            throw GHError.network(status: http.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        if includePrereleases {
+            let releases = try decoder.decode([GHRelease].self, from: data)
+            if let stable = releases.first(where: { !$0.prerelease }) {
+                return stable
+            }
+            if let first = releases.first {
+                return first
+            }
+            throw GHError.parse
+        } else {
+            return try decoder.decode(GHRelease.self, from: data)
+        }
+    }
+
+    public func fetchChecksums(from release: GHRelease) async throws -> [String: String] {
+        if let checksumAsset = release.assets.first(where: { $0.name.lowercased() == "checksums.txt" }) {
+            let (data, response) = try await session.data(from: checksumAsset.browserDownloadURL)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                throw GHError.network(status: (response as? HTTPURLResponse)?.statusCode ?? -1)
+            }
+            return parseChecksums(from: data)
+        }
+
+        if let body = release.body {
+            if let range = body.range(of: #"(?i)sha256[:\s]+([a-f0-9]{64})"#, options: .regularExpression) {
+                let substring = body[range]
+                let hash = substring.split(whereSeparator: { $0.isWhitespace || $0 == ":" }).last
+                if let hash, hash.count == 64 {
+                    return ["GatekeeperHelper": String(hash)]
+                }
+            }
+        }
+
+        throw GHError.checksumMissing
+    }
+
+    private func parseChecksums(from data: Data) -> [String: String] {
+        guard let string = String(data: data, encoding: .utf8) else { return [:] }
+        var mapping: [String: String] = [:]
+        string.enumerateLines { line, _ in
+            let parts = line.split(whereSeparator: { $0.isWhitespace })
+            if parts.count >= 3 {
+                let hash = String(parts[1])
+                let name = String(parts[2])
+                mapping[name] = hash
+            }
+        }
+        return mapping
+    }
+}

--- a/Sources/App/Services/InstallPlan.swift
+++ b/Sources/App/Services/InstallPlan.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct InstallPlan: Codable, Sendable {
+    public let newAppPath: String
+    public let targetAppPath: String
+    public let backupDir: String
+    public let relaunchBundleID: String
+    public let logFile: String
+    public let removeQuarantine: Bool
+}

--- a/Sources/App/Services/LaunchAgentManager.swift
+++ b/Sources/App/Services/LaunchAgentManager.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Darwin
+
+public enum LaunchAgentError: Error, LocalizedError {
+    case templateMissing
+    case writeFailed
+    case commandFailed(Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .templateMissing:
+            return "缺少 LaunchAgent 模板文件。"
+        case .writeFailed:
+            return "无法写入 LaunchAgent 文件。"
+        case .commandFailed(let code):
+            return "launchctl 执行失败，退出码 \(code)。"
+        }
+    }
+}
+
+public struct LaunchAgentManager {
+    private let fileManager = FileManager.default
+    private let logger: UpdaterLogger
+
+    public init(logger: UpdaterLogger = .shared) {
+        self.logger = logger
+    }
+
+    private var agentDestination: URL {
+        fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/com.gkh.updater.plist")
+    }
+
+    public func installAgentIfNeeded(programPath: String, hour: Int = 10, minute: Int = 0) async throws {
+        guard let templateURL = Bundle.main.url(forResource: "com.gkh.updater.plist", withExtension: "template", subdirectory: "LaunchAgents") else {
+            await logger.log("LaunchAgent 模板缺失", level: .error)
+            throw LaunchAgentError.templateMissing
+        }
+        var template = try String(contentsOf: templateURL)
+        template = template
+            .replacingOccurrences(of: "/Applications/GatekeeperHelper.app/Contents/MacOS/GKHCLIUpdater", with: programPath)
+            .replacingOccurrences(of: "<HOUR>", with: String(hour))
+            .replacingOccurrences(of: "<MINUTE>", with: String(minute))
+        let destination = agentDestination
+        try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        do {
+            try template.write(to: destination, atomically: true, encoding: .utf8)
+        } catch {
+            await logger.log("写入 LaunchAgent 失败: \(error.localizedDescription)", level: .error)
+            throw LaunchAgentError.writeFailed
+        }
+        try await runLaunchCtl(arguments: ["bootstrap", "gui/\(geteuid())", destination.path])
+        await logger.log("LaunchAgent 已安装: \(destination.path)")
+    }
+
+    public func removeAgentIfNeeded() async throws {
+        let destination = agentDestination
+        if fileManager.fileExists(atPath: destination.path) {
+            try? await runLaunchCtl(arguments: ["bootout", "gui/\(geteuid())", destination.path])
+            try? fileManager.removeItem(at: destination)
+            await logger.log("LaunchAgent 已移除")
+        }
+    }
+
+    private func runLaunchCtl(arguments: [String]) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            await logger.log("launchctl 失败 code=\(process.terminationStatus)", level: .error)
+            throw LaunchAgentError.commandFailed(process.terminationStatus)
+        }
+    }
+}

--- a/Sources/App/Services/Log.swift
+++ b/Sources/App/Services/Log.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public enum UpdaterLogLevel: String {
+    case info = "INFO"
+    case warning = "WARN"
+    case error = "ERROR"
+}
+
+public actor UpdaterLogger {
+    public static let shared = UpdaterLogger()
+
+    private let fileManager = FileManager.default
+    private let logURL: URL
+
+    private init() {
+        let logsDir = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/GatekeeperHelper", isDirectory: true)
+        try? fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        logURL = logsDir.appendingPathComponent("Updater.log")
+    }
+
+    public func log(_ message: String, level: UpdaterLogLevel = .info) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let line = "[\(level.rawValue)] [\(timestamp)] \(message)\n"
+        if let data = line.data(using: .utf8) {
+            if fileManager.fileExists(atPath: logURL.path) {
+                if let handle = try? FileHandle(forWritingTo: logURL) {
+                    do {
+                        try handle.seekToEnd()
+                        try handle.write(contentsOf: data)
+                    } catch {
+                        print("[UpdaterLogger] Failed writing log: \(error)")
+                    }
+                    try? handle.close()
+                }
+            } else {
+                try? data.write(to: logURL)
+            }
+        }
+        #if DEBUG
+        print("[Updater] \(line.trimmingCharacters(in: .whitespacesAndNewlines))")
+        #endif
+    }
+
+    public func url() -> URL { logURL }
+
+    public func recentLines(limit: Int = 200) -> String {
+        guard let data = try? Data(contentsOf: logURL), let text = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        let lines = text.split(whereSeparator: { $0.isNewline })
+        return lines.suffix(limit).joined(separator: "\n")
+    }
+}

--- a/Sources/App/Services/Preferences.swift
+++ b/Sources/App/Services/Preferences.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum UpdatePreferencesKey {
+    public static let autoUpdateEnabled = "autoUpdateEnabled"
+    public static let autoUpdateIntervalHours = "autoUpdateIntervalHours"
+    public static let includePrereleases = "includePrereleases"
+    public static let autoDownloadWhenAvailable = "autoDownloadWhenAvailable"
+    public static let allowRemoveQuarantine = "allowRemoveQuarantine"
+    public static let lastCheckedAt = "lastCheckedAt"
+    public static let latestKnownVersion = "latestKnownVersion"
+}
+
+public struct UpdatePreferences: Sendable {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public var autoUpdateEnabled: Bool {
+        get { defaults.object(forKey: UpdatePreferencesKey.autoUpdateEnabled) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.autoUpdateEnabled) }
+    }
+
+    public var autoUpdateIntervalHours: Int {
+        get {
+            let value = defaults.object(forKey: UpdatePreferencesKey.autoUpdateIntervalHours) as? Int ?? 6
+            return value
+        }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.autoUpdateIntervalHours) }
+    }
+
+    public var includePrereleases: Bool {
+        get { defaults.object(forKey: UpdatePreferencesKey.includePrereleases) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.includePrereleases) }
+    }
+
+    public var autoDownloadWhenAvailable: Bool {
+        get { defaults.object(forKey: UpdatePreferencesKey.autoDownloadWhenAvailable) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.autoDownloadWhenAvailable) }
+    }
+
+    public var allowRemoveQuarantine: Bool {
+        get { defaults.object(forKey: UpdatePreferencesKey.allowRemoveQuarantine) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.allowRemoveQuarantine) }
+    }
+
+    public var lastCheckedAt: Date? {
+        get { defaults.object(forKey: UpdatePreferencesKey.lastCheckedAt) as? Date }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.lastCheckedAt) }
+    }
+
+    public var latestKnownVersion: String? {
+        get { defaults.string(forKey: UpdatePreferencesKey.latestKnownVersion) }
+        set { defaults.set(newValue, forKey: UpdatePreferencesKey.latestKnownVersion) }
+    }
+
+    public func reset() {
+        defaults.removeObject(forKey: UpdatePreferencesKey.autoUpdateEnabled)
+        defaults.removeObject(forKey: UpdatePreferencesKey.autoUpdateIntervalHours)
+        defaults.removeObject(forKey: UpdatePreferencesKey.includePrereleases)
+        defaults.removeObject(forKey: UpdatePreferencesKey.autoDownloadWhenAvailable)
+        defaults.removeObject(forKey: UpdatePreferencesKey.allowRemoveQuarantine)
+        defaults.removeObject(forKey: UpdatePreferencesKey.lastCheckedAt)
+        defaults.removeObject(forKey: UpdatePreferencesKey.latestKnownVersion)
+    }
+}

--- a/Sources/App/Services/UpdateChecker.swift
+++ b/Sources/App/Services/UpdateChecker.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public struct UpdateInfo: Sendable {
+    public let current: String
+    public let latest: String
+    public let asset: GHAsset
+    public let sha256: String
+    public let notes: String?
+    public let publishedAt: Date?
+}
+
+public enum UpdateCheckerError: Error, LocalizedError {
+    case alreadyLatest
+
+    public var errorDescription: String? {
+        switch self {
+        case .alreadyLatest:
+            return "当前已是最新版本。"
+        }
+    }
+}
+
+public final actor UpdateChecker {
+    private let api: GitHubAPI
+    private let preferences: UpdatePreferences
+    private let logger: UpdaterLogger
+    private let bundle: Bundle
+
+    public init(api: GitHubAPI, preferences: UpdatePreferences = UpdatePreferences(), logger: UpdaterLogger = .shared, bundle: Bundle = .main) {
+        self.api = api
+        self.preferences = preferences
+        self.logger = logger
+        self.bundle = bundle
+    }
+
+    public func check(includePrereleases: Bool) async throws -> UpdateInfo {
+        await logger.log("开始检查更新 (includePrereleases=\(includePrereleases))")
+        let release = try await api.latestRelease(includePrereleases: includePrereleases)
+        guard let versionAsset = release.assets.first(where: { $0.name.lowercased().hasSuffix(".zip") }) else {
+            await logger.log("最新 Release 缺少 zip 资产", level: .error)
+            throw GHError.noAsset
+        }
+
+        let checksums = try await api.fetchChecksums(from: release)
+        guard let sha256 = checksums[versionAsset.name] ?? checksums.values.first else {
+            await logger.log("未找到 \(versionAsset.name) 对应的 SHA256", level: .error)
+            throw GHError.checksumMissing
+        }
+
+        let localVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+        let remoteVersion = release.tagName
+        await logger.log("当前版本 \(localVersion)，远端版本 \(remoteVersion)")
+        preferences.lastCheckedAt = Date()
+        preferences.latestKnownVersion = remoteVersion
+
+        guard Versioning.isNewer(remote: remoteVersion, than: localVersion) else {
+            throw UpdateCheckerError.alreadyLatest
+        }
+
+        return UpdateInfo(
+            current: localVersion,
+            latest: remoteVersion,
+            asset: versionAsset,
+            sha256: sha256,
+            notes: release.body,
+            publishedAt: release.publishedAt
+        )
+    }
+}

--- a/Sources/App/Services/UpdateCoordinator.swift
+++ b/Sources/App/Services/UpdateCoordinator.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Combine
+import AppKit
+
+@MainActor
+public final class UpdateCoordinator: ObservableObject {
+    public enum Status {
+        case idle
+        case checking
+        case upToDate
+        case updateAvailable(UpdateInfo)
+        case downloading(Double)
+        case downloaded
+        case installing
+        case error(String)
+    }
+
+    @Published public private(set) var status: Status = .idle
+    @Published public private(set) var lastErrorMessage: String?
+    @Published public private(set) var lastCheckedAt: Date?
+    @Published public private(set) var latestKnownVersion: String?
+    @Published public private(set) var currentVersion: String
+
+    public var autoUpdateEnabled: Bool {
+        get { preferences.autoUpdateEnabled }
+        set {
+            preferences.autoUpdateEnabled = newValue
+            configureTimer()
+        }
+    }
+
+    public var autoUpdateIntervalHours: Int {
+        get { preferences.autoUpdateIntervalHours }
+        set {
+            preferences.autoUpdateIntervalHours = newValue
+            configureTimer()
+        }
+    }
+
+    public var includePrereleases: Bool {
+        get { preferences.includePrereleases }
+        set { preferences.includePrereleases = newValue }
+    }
+
+    public var autoDownloadWhenAvailable: Bool {
+        get { preferences.autoDownloadWhenAvailable }
+        set { preferences.autoDownloadWhenAvailable = newValue }
+    }
+
+    public var allowRemoveQuarantine: Bool {
+        get { preferences.allowRemoveQuarantine }
+        set { preferences.allowRemoveQuarantine = newValue }
+    }
+
+    private let checker: UpdateChecker
+    private let downloader: UpdateDownloader
+    private let installer: UpdateInstaller
+    private let preferences: UpdatePreferences
+    private let logger: UpdaterLogger
+    private var autoTimer: Timer?
+    private var cancellables: Set<AnyCancellable> = []
+    private var downloadedUpdate: DownloadedUpdate?
+
+    public init(checker: UpdateChecker, downloader: UpdateDownloader, installer: UpdateInstaller, preferences: UpdatePreferences = UpdatePreferences(), logger: UpdaterLogger = .shared) {
+        self.checker = checker
+        self.downloader = downloader
+        self.installer = installer
+        self.preferences = preferences
+        self.logger = logger
+        self.currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+        self.lastCheckedAt = preferences.lastCheckedAt
+        self.latestKnownVersion = preferences.latestKnownVersion
+        bindDownloader()
+        configureTimer()
+    }
+
+    private func bindDownloader() {
+        downloader.onProgress = { [weak self] progress in
+            let fraction: Double
+            if progress.total > 0 {
+                fraction = Double(progress.received) / Double(progress.total)
+            } else {
+                fraction = 0
+            }
+            Task { @MainActor in
+                self?.status = .downloading(fraction)
+            }
+        }
+    }
+
+    private func configureTimer() {
+        autoTimer?.invalidate()
+        guard autoUpdateEnabled else { return }
+        let interval = TimeInterval(autoUpdateIntervalHours * 3600)
+        guard interval > 0 else { return }
+        let jitterMinutes = Double(Int.random(in: 5...15)) * 60
+        let timer = Timer(timeInterval: interval + jitterMinutes, repeats: true) { [weak self] _ in
+            Task { await self?.autoCheck() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        autoTimer = timer
+    }
+
+    private func autoCheck() async {
+        await logger.log("触发自动检查更新")
+        await checkForUpdates(manual: false)
+    }
+
+    public func checkForUpdates(manual: Bool) async {
+        status = .checking
+        lastErrorMessage = nil
+        do {
+            let info = try await checker.check(includePrereleases: includePrereleases)
+            latestKnownVersion = info.latest
+            preferences.latestKnownVersion = info.latest
+            lastCheckedAt = preferences.lastCheckedAt
+            status = .updateAvailable(info)
+            if autoDownloadWhenAvailable && !manual {
+                await startDownload(for: info)
+            }
+        } catch UpdateCheckerError.alreadyLatest {
+            lastCheckedAt = preferences.lastCheckedAt
+            status = .upToDate
+            await logger.log("当前已是最新版本")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            lastErrorMessage = message
+            status = .error(message)
+            await logger.log("检查更新失败: \(message)", level: .error)
+        }
+    }
+
+    public func startDownload(for info: UpdateInfo) async {
+        status = .downloading(0)
+        do {
+            let downloaded = try await downloader.download(asset: info.asset, sha256: info.sha256)
+            downloadedUpdate = downloaded
+            status = .downloaded
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            lastErrorMessage = message
+            status = .error(message)
+            await logger.log("下载更新失败: \(message)", level: .error)
+        }
+    }
+
+    public func installUpdate() async {
+        guard let downloadedUpdate else { return }
+        status = .installing
+        do {
+            _ = try await installer.install(newAppPath: downloadedUpdate.extractedAppURL, removeQuarantine: allowRemoveQuarantine)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            lastErrorMessage = message
+            status = .error(message)
+            await logger.log("安装更新失败: \(message)", level: .error)
+        }
+    }
+
+    public func cancelScheduledChecks() {
+        autoTimer?.invalidate()
+        autoTimer = nil
+    }
+}

--- a/Sources/App/Services/UpdateDownloader.swift
+++ b/Sources/App/Services/UpdateDownloader.swift
@@ -1,0 +1,132 @@
+import Foundation
+#if canImport(ZipFoundation)
+import ZipFoundation
+#endif
+
+public struct DownloadedUpdate: Sendable {
+    public let extractedAppURL: URL
+    public let archiveURL: URL
+}
+
+public final class UpdateDownloader: NSObject, URLSessionDownloadDelegate {
+    public struct Progress: Sendable {
+        public let received: Int64
+        public let total: Int64
+    }
+
+    public var onProgress: ((Progress) -> Void)?
+
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.allowsExpensiveNetworkAccess = true
+        configuration.allowsConstrainedNetworkAccess = true
+        configuration.timeoutIntervalForRequest = 60
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    private let logger: UpdaterLogger
+
+    public init(logger: UpdaterLogger = .shared) {
+        self.logger = logger
+    }
+
+    public func download(asset: GHAsset, sha256: String) async throws -> DownloadedUpdate {
+        await logger.log("开始下载更新: \(asset.name) 大小 \(asset.size)")
+        let (tempURL, response) = try await session.download(from: asset.browserDownloadURL)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            await logger.log("下载失败 status=\((response as? HTTPURLResponse)?.statusCode ?? -1)", level: .error)
+            throw GHError.network(status: (response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let archiveURL = temporaryDirectory.appendingPathComponent(asset.name)
+        try? FileManager.default.removeItem(at: archiveURL)
+        try FileManager.default.moveItem(at: tempURL, to: archiveURL)
+        let digest = try Checksum.sha256(for: archiveURL)
+        guard digest.lowercased() == sha256.lowercased() else {
+            await logger.log("SHA256 校验失败 expected=\(sha256) actual=\(digest)", level: .error)
+            try? FileManager.default.removeItem(at: archiveURL)
+            throw UpdateDownloadError.checksumMismatch
+        }
+        await logger.log("SHA256 校验通过")
+
+        let extractionURL = temporaryDirectory.appendingPathComponent("GKHNew", isDirectory: true)
+        try? FileManager.default.removeItem(at: extractionURL)
+        try FileManager.default.createDirectory(at: extractionURL, withIntermediateDirectories: true)
+        try await unzip(archive: archiveURL, to: extractionURL)
+
+        let appURL = extractionURL.appendingPathComponent("GatekeeperHelper.app")
+        guard FileManager.default.fileExists(atPath: appURL.path) else {
+            await logger.log("解压后未找到 GatekeeperHelper.app", level: .error)
+            throw UpdateDownloadError.missingAppBundle
+        }
+
+        await logger.log("下载并解压完成，路径: \(appURL.path)")
+        return DownloadedUpdate(extractedAppURL: appURL, archiveURL: archiveURL)
+    }
+
+    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        let progress = Progress(received: totalBytesWritten, total: totalBytesExpectedToWrite)
+        DispatchQueue.main.async { [weak self] in
+            self?.onProgress?(progress)
+        }
+    }
+
+    private func unzip(archive: URL, to destination: URL) async throws {
+        if try await unzipWithZipFoundation(archive: archive, to: destination) {
+            return
+        }
+        try await unzipWithCLI(archive: archive, to: destination)
+    }
+
+    private func unzipWithZipFoundation(archive: URL, to destination: URL) async throws -> Bool {
+        #if canImport(ZipFoundation)
+        guard let zipArchive = Archive(url: archive, accessMode: .read) else {
+            return false
+        }
+        for entry in zipArchive {
+            let destinationURL = destination.appendingPathComponent(entry.path)
+            let directoryURL = destinationURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            _ = try zipArchive.extract(entry, to: destinationURL)
+        }
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    private func unzipWithCLI(archive: URL, to destination: URL) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = [archive.path, "-d", destination.path]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if process.terminationStatus != 0 {
+            let message = String(data: data, encoding: .utf8) ?? "unknown"
+            await logger.log("unzip 失败: \(message)", level: .error)
+            throw UpdateDownloadError.unzipFailed(message: message)
+        }
+    }
+}
+
+public enum UpdateDownloadError: Error, LocalizedError {
+    case checksumMismatch
+    case missingAppBundle
+    case unzipFailed(message: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .checksumMismatch:
+            return "下载文件的 SHA-256 校验失败，可能被篡改。"
+        case .missingAppBundle:
+            return "解压后的文件缺少 GatekeeperHelper.app。"
+        case .unzipFailed(let message):
+            return "解压失败：\(message)"
+        }
+    }
+}

--- a/Sources/App/Services/UpdateInstaller.swift
+++ b/Sources/App/Services/UpdateInstaller.swift
@@ -1,0 +1,71 @@
+import Foundation
+import AppKit
+
+public enum UpdateInstallerError: Error, LocalizedError {
+    case helperNotFound
+    case failedToLaunchHelper
+
+    public var errorDescription: String? {
+        switch self {
+        case .helperNotFound:
+            return "未找到 Updater Helper 程序。"
+        case .failedToLaunchHelper:
+            return "无法启动 Updater Helper。"
+        }
+    }
+}
+
+public final class UpdateInstaller {
+    private let logger: UpdaterLogger
+
+    public init(logger: UpdaterLogger = .shared) {
+        self.logger = logger
+    }
+
+    public func install(newAppPath: URL, removeQuarantine: Bool) async throws -> Never {
+        let bundle = Bundle.main
+        let targetURL = bundle.bundleURL
+        let backupDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/GatekeeperHelper/PreviousVersions", isDirectory: true)
+        try FileManager.default.createDirectory(at: backupDir, withIntermediateDirectories: true)
+
+        let plan = InstallPlan(
+            newAppPath: newAppPath.path,
+            targetAppPath: targetURL.path,
+            backupDir: backupDir.path,
+            relaunchBundleID: bundle.bundleIdentifier ?? "",
+            logFile: await logger.url().path,
+            removeQuarantine: removeQuarantine
+        )
+
+        let planURL = FileManager.default.temporaryDirectory.appendingPathComponent("InstallPlan.json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let data = try encoder.encode(plan)
+        try data.write(to: planURL, options: .atomic)
+
+        let helperURL = bundle.url(forAuxiliaryExecutable: "UpdaterHelper")
+        guard let helperURL else {
+            await logger.log("未找到 UpdaterHelper 可执行文件", level: .error)
+            throw UpdateInstallerError.helperNotFound
+        }
+
+        let process = Process()
+        process.executableURL = helperURL
+        process.arguments = ["--plan", planURL.path]
+
+        await logger.log("启动 Helper 执行安装: \(helperURL.path) plan=\(planURL.path)")
+        do {
+            try process.run()
+        } catch {
+            await logger.log("启动 Helper 失败: \(error.localizedDescription)", level: .error)
+            throw UpdateInstallerError.failedToLaunchHelper
+        }
+
+        await MainActor.run {
+            NSApp.terminate(nil)
+        }
+        RunLoop.current.run()
+        fatalError("NSApp.terminate 未返回")
+    }
+}

--- a/Sources/App/Services/Versioning.swift
+++ b/Sources/App/Services/Versioning.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct Semver: Comparable, Codable {
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+
+    public init(_ versionString: String) {
+        let trimmed = versionString
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
+        let components = trimmed.split(separator: ".").map { Int($0) ?? 0 }
+        major = components.indices.contains(0) ? components[0] : 0
+        minor = components.indices.contains(1) ? components[1] : 0
+        patch = components.indices.contains(2) ? components[2] : 0
+    }
+
+    public init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    public static func < (lhs: Semver, rhs: Semver) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+
+    public var stringValue: String {
+        "\(major).\(minor).\(patch)"
+    }
+}
+
+public enum Versioning {
+    public static func isNewer(remote: String, than local: String) -> Bool {
+        Semver(remote) > Semver(local)
+    }
+}

--- a/Sources/App/UI/Dialogs/UpdateCheckView.swift
+++ b/Sources/App/UI/Dialogs/UpdateCheckView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+struct UpdateCheckView: View {
+    @ObservedObject var coordinator: UpdateCoordinator
+    @Binding var isPresented: Bool
+
+    @State private var isDownloading = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("检查更新")
+                .font(.title2)
+                .bold()
+
+            Divider()
+
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 8)
+
+            HStack {
+                Button("关闭") { isPresented = false }
+                Spacer()
+                if case .updateAvailable(let info) = coordinator.status {
+                    Button("下载并更新") {
+                        Task { await coordinator.startDownload(for: info) }
+                    }
+                } else if case .downloaded = coordinator.status {
+                    Button("安装并重启") {
+                        Task { await coordinator.installUpdate() }
+                    }
+                }
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 440, minHeight: 320)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch coordinator.status {
+        case .idle:
+            Text("准备就绪，点击“检查更新”开始。")
+                .foregroundColor(.secondary)
+        case .checking:
+            HStack(spacing: 12) {
+                ProgressView()
+                Text("正在联系 GitHub Releases…")
+            }
+        case .upToDate:
+            Label("当前版本已是最新。", systemImage: "checkmark.seal")
+                .foregroundColor(.green)
+        case .updateAvailable(let info):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("发现新版本 \(info.latest)", systemImage: "arrow.down.circle")
+                    .font(.headline)
+                if let publishedAt = info.publishedAt {
+                    Text("发布时间：\(formatted(date: publishedAt))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let notes = info.notes, !notes.isEmpty {
+                    Text("更新摘要：")
+                        .font(.subheadline)
+                        .bold()
+                    ScrollView {
+                        Text(notes)
+                            .font(.callout)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 160)
+                    .background(.regularMaterial)
+                    .cornerRadius(8)
+                }
+            }
+        case .downloading(let progress):
+            VStack(alignment: .leading, spacing: 12) {
+                Text("正在下载更新…")
+                ProgressView(value: progress)
+                Text(String(format: "%.0f%%", progress * 100))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        case .downloaded:
+            Label("下载完成，准备安装。", systemImage: "tray.and.arrow.down.fill")
+        case .installing:
+            HStack(spacing: 12) {
+                ProgressView()
+                Text("正在安装并重启，请稍候…")
+            }
+        case .error(let message):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("更新失败", systemImage: "exclamationmark.triangle")
+                    .foregroundColor(.orange)
+                    .font(.headline)
+                Text(message)
+                    .font(.callout)
+                Button("复制日志") {
+                    Task {
+                        let logs = await UpdaterLogger.shared.recentLines()
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(logs, forType: .string)
+                    }
+                }
+                Button("提交 Issue") {
+                    if let url = URL(string: "https://github.com/Tang1206cc/GatekeeperHelper/issues/new/choose") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            }
+        }
+    }
+
+    private func formatted(date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/App/UI/Settings/UpdateSettingsView.swift
+++ b/Sources/App/UI/Settings/UpdateSettingsView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+import AppKit
+
+struct UpdateSettingsView: View {
+    @StateObject private var coordinator = UpdateSettingsView.makeCoordinator()
+    @State private var showingUpdateSheet = false
+    @State private var copiedLogs = false
+
+    private let issueURL = URL(string: "https://github.com/Tang1206cc/GatekeeperHelper/issues/new/choose")!
+    private let releasesURL = URL(string: "https://github.com/Tang1206cc/GatekeeperHelper/releases")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            SectionHeader(title: "更新")
+
+            Toggle("自动检查更新", isOn: Binding(
+                get: { coordinator.autoUpdateEnabled },
+                set: { coordinator.autoUpdateEnabled = $0 }
+            ))
+
+            HStack(spacing: 16) {
+                Text("检查频率")
+                Picker("检查频率", selection: Binding(
+                    get: { coordinator.autoUpdateIntervalHours },
+                    set: { coordinator.autoUpdateIntervalHours = $0 }
+                )) {
+                    Text("仅在启动时").tag(0)
+                    Text("每 6 小时").tag(6)
+                    Text("每 12 小时").tag(12)
+                    Text("每日").tag(24)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 320)
+            }
+            .opacity(coordinator.autoUpdateEnabled ? 1 : 0.5)
+            .disabled(!coordinator.autoUpdateEnabled)
+
+            Toggle("包含 Beta 版本", isOn: Binding(
+                get: { coordinator.includePrereleases },
+                set: { coordinator.includePrereleases = $0 }
+            ))
+
+            Toggle("有新版本时自动下载", isOn: Binding(
+                get: { coordinator.autoDownloadWhenAvailable },
+                set: { coordinator.autoDownloadWhenAvailable = $0 }
+            ))
+
+            Toggle("允许更新器在安装后移除 Gatekeeper 隔离属性", isOn: Binding(
+                get: { coordinator.allowRemoveQuarantine },
+                set: { coordinator.allowRemoveQuarantine = $0 }
+            ))
+            .help("建议保持勾选，使后续更新后的首次启动更顺畅。此操作仅针对 GatekeeperHelper.app 生效。")
+
+            Button("查看 Gatekeeper 放行指南…") {
+                if let url = Bundle.main.url(forResource: "GatekeeperGuide", withExtension: "md", subdirectory: "Privacy") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("当前版本：")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                    Text(coordinator.currentVersion)
+                        .fontWeight(.semibold)
+                }
+                HStack {
+                    Text("最新版本：")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                    Text(coordinator.latestKnownVersion ?? "-")
+                        .fontWeight(.semibold)
+                    if let lastChecked = coordinator.lastCheckedAt {
+                        Text("（上次检查：\(formatted(date: lastChecked))）")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("检查更新…") {
+                    showingUpdateSheet = true
+                    Task { await coordinator.checkForUpdates(manual: true) }
+                }
+                Button("查看更新日志…") {
+                    NSWorkspace.shared.open(releasesURL)
+                }
+                Button("打开日志文件夹") {
+                    let url = try? FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+                        .appendingPathComponent("Logs/GatekeeperHelper", isDirectory: true)
+                    if let url { NSWorkspace.shared.open(url) }
+                }
+                Button("复制最近日志") {
+                    Task {
+                        let logs = await UpdaterLogger.shared.recentLines()
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(logs, forType: .string)
+                        copiedLogs = true
+                    }
+                }
+                Button("提交 Issue") {
+                    NSWorkspace.shared.open(issueURL)
+                }
+            }
+
+            if copiedLogs {
+                Text("已复制最近日志，可以前往 Issue 粘贴。")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .sheet(isPresented: $showingUpdateSheet) {
+            UpdateCheckView(coordinator: coordinator, isPresented: $showingUpdateSheet)
+                .frame(minWidth: 420, minHeight: 320)
+        }
+        .onAppear {
+            Task { await coordinator.checkForUpdates(manual: false) }
+        }
+    }
+
+    private func formatted(date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private static func makeCoordinator() -> UpdateCoordinator {
+        let prefs = UpdatePreferences()
+        let logger = UpdaterLogger.shared
+        let api = GitHubAPIClient(owner: "Tang1206cc", repo: "GatekeeperHelper")
+        let checker = UpdateChecker(api: api, preferences: prefs, logger: logger)
+        let downloader = UpdateDownloader(logger: logger)
+        let installer = UpdateInstaller(logger: logger)
+        return UpdateCoordinator(checker: checker, downloader: downloader, installer: installer, preferences: prefs, logger: logger)
+    }
+}
+
+private struct SectionHeader: View {
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.title3)
+                .bold()
+            Divider()
+        }
+    }
+}

--- a/Sources/GKHCLIUpdater/main.swift
+++ b/Sources/GKHCLIUpdater/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@main
+struct GKHCLIUpdater {
+    static func main() async {
+        let arguments = CommandLine.arguments
+        guard arguments.contains("--check") else {
+            print("用法: GKHCLIUpdater --check")
+            return
+        }
+        let prefs = UpdatePreferences()
+        let logger = UpdaterLogger.shared
+        let api = GitHubAPIClient(owner: "Tang1206cc", repo: "GatekeeperHelper")
+        let checker = UpdateChecker(api: api, preferences: prefs, logger: logger)
+        do {
+            let info = try await checker.check(includePrereleases: prefs.includePrereleases)
+            print("发现新版本: \(info.latest)")
+        } catch UpdateCheckerError.alreadyLatest {
+            print("当前已是最新版本。")
+        } catch {
+            print("检查更新失败: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/UpdaterHelper/FileOps.swift
+++ b/Sources/UpdaterHelper/FileOps.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct HelperLogger {
+    let logURL: URL
+    private let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    func log(_ message: String) {
+        let line = "[HELPER] [\(formatter.string(from: Date()))] \(message)\n"
+        if let data = line.data(using: .utf8) {
+            if FileManager.default.fileExists(atPath: logURL.path) {
+                if let handle = try? FileHandle(forWritingTo: logURL) {
+                    try? handle.seekToEnd()
+                    try? handle.write(contentsOf: data)
+                    try? handle.close()
+                }
+            } else {
+                try? data.write(to: logURL)
+            }
+        }
+    }
+}
+
+enum HelperError: Error {
+    case planMissing
+    case unableToReadPlan
+    case fileOperation(String)
+    case relaunchFailed
+}
+
+struct FileOps {
+    let fileManager = FileManager.default
+
+    func backupAndReplace(plan: HelperInstallPlan, logger: HelperLogger) throws {
+        logger.log("开始执行替换流程")
+        try fileManager.createDirectory(at: plan.backupDirectoryURL, withIntermediateDirectories: true)
+        var backupURL: URL?
+        if fileManager.fileExists(atPath: plan.targetAppURL.path) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd-HHmmss"
+            let timestamp = formatter.string(from: Date())
+            backupURL = plan.backupDirectoryURL.appendingPathComponent("GatekeeperHelper-\(timestamp).app")
+            logger.log("备份旧版到 \(backupURL!.path)")
+            do {
+                if fileManager.fileExists(atPath: backupURL!.path) {
+                    try fileManager.removeItem(at: backupURL!)
+                }
+                try fileManager.moveItem(at: plan.targetAppURL, to: backupURL!)
+            } catch {
+                logger.log("备份失败: \(error.localizedDescription)")
+                throw HelperError.fileOperation("备份失败")
+            }
+        }
+
+        do {
+            if fileManager.fileExists(atPath: plan.targetAppURL.path) {
+                try fileManager.removeItem(at: plan.targetAppURL)
+            }
+            try fileManager.copyItem(at: plan.newAppURL, to: plan.targetAppURL)
+        } catch {
+            logger.log("复制新版本失败: \(error.localizedDescription)")
+            if let backupURL {
+                try? restoreBackup(from: backupURL, to: plan.targetAppURL, logger: logger)
+            }
+            throw HelperError.fileOperation("复制新版本失败")
+        }
+
+        logger.log("替换完成")
+    }
+
+    private func restoreBackup(from backup: URL, to target: URL, logger: HelperLogger) throws {
+        if fileManager.fileExists(atPath: target.path) {
+            try? fileManager.removeItem(at: target)
+        }
+        try fileManager.moveItem(at: backup, to: target)
+        logger.log("已回滚到备份版本")
+    }
+
+    func removeQuarantineIfNeeded(plan: HelperInstallPlan, logger: HelperLogger) {
+        guard plan.removeQuarantine else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xattr")
+        process.arguments = ["-dr", "com.apple.quarantine", plan.targetAppURL.path]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            logger.log("执行 xattr 返回码 \(process.terminationStatus)")
+        } catch {
+            logger.log("移除隔离属性失败: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/UpdaterHelper/HelperInstallPlan.swift
+++ b/Sources/UpdaterHelper/HelperInstallPlan.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct HelperInstallPlan: Codable {
+    let newAppPath: String
+    let targetAppPath: String
+    let backupDir: String
+    let relaunchBundleID: String
+    let logFile: String
+    let removeQuarantine: Bool
+
+    var newAppURL: URL { URL(fileURLWithPath: newAppPath) }
+    var targetAppURL: URL { URL(fileURLWithPath: targetAppPath) }
+    var backupDirectoryURL: URL { URL(fileURLWithPath: backupDir, isDirectory: true) }
+    var logFileURL: URL { URL(fileURLWithPath: logFile) }
+}

--- a/Sources/UpdaterHelper/Relaunch.swift
+++ b/Sources/UpdaterHelper/Relaunch.swift
@@ -1,0 +1,30 @@
+import Foundation
+import AppKit
+
+struct Relauncher {
+    func waitForTermination(bundleID: String, logger: HelperLogger) {
+        guard !bundleID.isEmpty else { return }
+        logger.log("等待主程序退出：\(bundleID)")
+        let timeout: TimeInterval = 60
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            if running.isEmpty { break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+    }
+
+    func relaunch(bundleID: String, logger: HelperLogger) throws {
+        guard !bundleID.isEmpty else { return }
+        logger.log("尝试通过 open -b \(bundleID) 重启应用")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-b", bundleID]
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            logger.log("open 退出码 \(process.terminationStatus)")
+            throw HelperError.relaunchFailed
+        }
+    }
+}

--- a/Sources/UpdaterHelper/main.swift
+++ b/Sources/UpdaterHelper/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+import AppKit
+
+@main
+struct UpdaterHelperMain {
+    static func main() async {
+        let arguments = CommandLine.arguments
+        guard let planIndex = arguments.firstIndex(of: "--plan"), planIndex + 1 < arguments.count else {
+            fputs("UpdaterHelper 缺少 --plan 参数\n", stderr)
+            exit(2)
+        }
+
+        let planPath = arguments[planIndex + 1]
+        let planURL = URL(fileURLWithPath: planPath)
+        do {
+            let data = try Data(contentsOf: planURL)
+            let plan = try JSONDecoder().decode(HelperInstallPlan.self, from: data)
+            let logger = HelperLogger(logURL: plan.logFileURL)
+            logger.log("Helper 启动，计划文件：\(planPath)")
+            try execute(plan: plan, logger: logger)
+            exit(0)
+        } catch {
+            fputs("UpdaterHelper 执行失败: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func execute(plan: HelperInstallPlan, logger: HelperLogger) throws {
+        let ops = FileOps()
+        let relauncher = Relauncher()
+        relauncher.waitForTermination(bundleID: plan.relaunchBundleID, logger: logger)
+        try ops.backupAndReplace(plan: plan, logger: logger)
+        ops.removeQuarantineIfNeeded(plan: plan, logger: logger)
+        do {
+            try relauncher.relaunch(bundleID: plan.relaunchBundleID, logger: logger)
+            logger.log("重启命令已触发")
+        } catch {
+            logger.log("重启失败: \(error.localizedDescription)")
+            throw error
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement the GitHub release-backed updater stack covering version parsing, API client, download/verify and installation orchestration
- integrate a redesigned preferences section and update flow UI with logging utilities and Gatekeeper guidance
- add the helper executable, CLI tooling, launch agent template, release scripts and accompanying documentation

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ea8ba3195483238b077f0284a74363