### PR TITLE
Add in-app update workflow

### DIFF
--- a/GatekeeperHelper/SettingsView.swift
+++ b/GatekeeperHelper/SettingsView.swift
@@ -13,6 +13,13 @@ struct SettingsView: View {
     @AppStorage("escToQuit") private var escToQuit = false
     @AppStorage("quitWhenLastWindowClosed") private var quitWhenLastWindowClosed = true
 
+    private var currentVersionText: String {
+        if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String, !version.isEmpty {
+            return "当前版本：v\(version)"
+        }
+        return "当前版本：—"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("偏好设置")
@@ -47,12 +54,25 @@ struct SettingsView: View {
 
             Spacer()
 
-            Button("恢复默认设置") {
-                AppSettings.reset()
-                launchAtLogin = false
-                themeMode = ThemeMode.system.rawValue
-                escToQuit = false
-                quitWhenLastWindowClosed = true
+            HStack(alignment: .center, spacing: 12) {
+                Button("恢复默认设置") {
+                    AppSettings.reset()
+                    launchAtLogin = false
+                    themeMode = ThemeMode.system.rawValue
+                    escToQuit = false
+                    quitWhenLastWindowClosed = true
+                }
+
+                Spacer()
+
+                Text(currentVersionText)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+
+                Button("检查更新") {
+                    UpdateManager.shared.checkForUpdate(interactive: true)
+                }
+                .buttonStyle(.borderedProminent)
             }
             .padding(.bottom, 8)
         }

--- a/GatekeeperHelper/Update/DownloadWindowController.swift
+++ b/GatekeeperHelper/Update/DownloadWindowController.swift
@@ -1,0 +1,159 @@
+import AppKit
+
+final class DownloadWindowController: NSWindowController, URLSessionDownloadDelegate {
+    private let progressIndicator = NSProgressIndicator()
+    private let percentField = NSTextField(labelWithString: "下载进度：0%")
+    private let etaField = NSTextField(labelWithString: "剩余时间：—")
+
+    private var session: URLSession?
+    private var startTime: Date?
+    private var completion: ((Result<URL, Error>) -> Void)?
+
+    convenience init() {
+        self.init(window: nil)
+        setupWindow()
+    }
+
+    override init(window: NSWindow?) {
+        super.init(window: window)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupWindow() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 150),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.center()
+        window.title = "正在下载"
+        window.isReleasedWhenClosed = false
+        window.standardWindowButton(.closeButton)?.isEnabled = false
+        window.standardWindowButton(.zoomButton)?.isEnabled = false
+        window.standardWindowButton(.miniaturizeButton)?.isEnabled = true
+        window.collectionBehavior = []
+
+        let contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        window.contentView = contentView
+
+        progressIndicator.translatesAutoresizingMaskIntoConstraints = false
+        progressIndicator.isIndeterminate = false
+        progressIndicator.minValue = 0
+        progressIndicator.maxValue = 1
+        progressIndicator.doubleValue = 0
+        progressIndicator.controlSize = .regular
+        progressIndicator.style = .bar
+
+        percentField.translatesAutoresizingMaskIntoConstraints = false
+        percentField.font = .systemFont(ofSize: 13)
+
+        etaField.translatesAutoresizingMaskIntoConstraints = false
+        etaField.font = .systemFont(ofSize: 12)
+        etaField.alignment = .right
+
+        contentView.addSubview(percentField)
+        contentView.addSubview(progressIndicator)
+        contentView.addSubview(etaField)
+
+        NSLayoutConstraint.activate([
+            percentField.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            percentField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+
+            progressIndicator.topAnchor.constraint(equalTo: percentField.bottomAnchor, constant: 12),
+            progressIndicator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            progressIndicator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+
+            etaField.topAnchor.constraint(equalTo: progressIndicator.bottomAnchor, constant: 12),
+            etaField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            etaField.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20)
+        ])
+
+        self.window = window
+    }
+
+    func startDownload(from url: URL, completion: @escaping (Result<URL, Error>) -> Void) {
+        self.completion = completion
+        percentField.stringValue = "下载进度：0%"
+        etaField.stringValue = "剩余时间：—"
+        progressIndicator.doubleValue = 0
+        progressIndicator.isIndeterminate = false
+        startTime = Date()
+
+        let configuration = URLSessionConfiguration.ephemeral
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+        self.session = session
+        session.downloadTask(with: url).resume()
+
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    // MARK: URLSessionDownloadDelegate
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64,
+                    totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+
+        let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        progressIndicator.doubleValue = progress
+        percentField.stringValue = String(format: "下载进度：%.0f%%", progress * 100)
+
+        if let startTime, totalBytesWritten > 0 {
+            let elapsed = Date().timeIntervalSince(startTime)
+            let speed = Double(totalBytesWritten) / max(elapsed, 0.1)
+            let remainingBytes = Double(totalBytesExpectedToWrite - totalBytesWritten)
+            let remainingTime = remainingBytes / max(speed, 1)
+            etaField.stringValue = "剩余时间：" + format(seconds: Int(remainingTime))
+        }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        let destination = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("zip")
+        do {
+            try FileManager.default.moveItem(at: location, to: destination)
+            complete(with: .success(destination), cancelTasks: false)
+        } catch {
+            complete(with: .failure(error), cancelTasks: true)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error {
+            complete(with: .failure(error), cancelTasks: true)
+        }
+    }
+
+    private func complete(with result: Result<URL, Error>, cancelTasks: Bool) {
+        window?.orderOut(nil)
+        if cancelTasks {
+            session?.invalidateAndCancel()
+        } else {
+            session?.finishTasksAndInvalidate()
+        }
+        session = nil
+        let completion = self.completion
+        self.completion = nil
+        completion?(result)
+    }
+
+    private func format(seconds: Int) -> String {
+        let minutes = seconds / 60
+        let secs = seconds % 60
+        if minutes > 0 {
+            return "\(minutes) 分 \(secs) 秒"
+        } else {
+            return "\(secs) 秒"
+        }
+    }
+}

--- a/GatekeeperHelper/Update/GitHubReleasesAPI.swift
+++ b/GatekeeperHelper/Update/GitHubReleasesAPI.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct GitHubAsset: Decodable {
+    let name: String
+    let browser_download_url: URL
+}
+
+struct GitHubRelease: Decodable {
+    let tag_name: String
+    let draft: Bool
+    let prerelease: Bool
+    let assets: [GitHubAsset]
+}
+
+enum GitHubAPI {
+    private static let owner = "Tang1206cc"
+    private static let repo = "GatekeeperHelper"
+
+    static func fetchLatestRelease(
+        usePrerelease: Bool = false,
+        token: String? = ProcessInfo.processInfo.environment["GITHUB_TOKEN"]
+    ) async throws -> GitHubRelease {
+        let url = URL(string: "https://api.github.com/repos/\(owner)/\(repo)/releases/latest")!
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw NSError(domain: "GitHub", code: 1, userInfo: [NSLocalizedDescriptionKey: "GitHub API 返回异常"])
+        }
+        return try JSONDecoder().decode(GitHubRelease.self, from: data)
+    }
+}

--- a/GatekeeperHelper/Update/Installer.swift
+++ b/GatekeeperHelper/Update/Installer.swift
@@ -1,0 +1,72 @@
+import AppKit
+import Foundation
+
+enum Installer {
+    private static let appName = "GatekeeperHelper.app"
+    private static let targetDirectory = URL(fileURLWithPath: "/Applications")
+
+    private static var targetAppURL: URL {
+        targetDirectory.appendingPathComponent(appName)
+    }
+
+    static func unzip(_ zipURL: URL, to destination: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-x", "-k", zipURL.path, destination.path]
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw NSError(domain: "Installer", code: 0, userInfo: [NSLocalizedDescriptionKey: "解压失败"])
+        }
+    }
+
+    static func installAndRelaunch(newAppURL: URL) throws {
+        let alert = NSAlert()
+        alert.messageText = "即将安装更新"
+        alert.informativeText = "应用将退出以完成安装。"
+        alert.addButton(withTitle: "继续")
+        alert.addButton(withTitle: "取消")
+        if alert.runModalWithSystemStyle() != .alertFirstButtonReturn {
+            return
+        }
+
+        let helperURL = Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/UpdaterHelper")
+        guard FileManager.default.isExecutableFile(atPath: helperURL.path) else {
+            throw NSError(domain: "Installer", code: 0, userInfo: [NSLocalizedDescriptionKey: "未找到更新助手"])
+        }
+
+        let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let planURL = tempDirectory.appendingPathComponent("GatekeeperHelper-InstallPlan-\(UUID().uuidString).json")
+        let backupDirectory = tempDirectory.appendingPathComponent("GatekeeperHelperBackups", isDirectory: true)
+        let logFileURL = tempDirectory.appendingPathComponent("GatekeeperHelperUpdater.log")
+
+        let plan = InstallPlan(
+            newAppPath: newAppURL.path,
+            targetAppPath: targetAppURL.path,
+            backupDir: backupDirectory.path,
+            removeQuarantine: true,
+            relaunchBundleID: Bundle.main.bundleIdentifier ?? "",
+            logFile: logFileURL.path
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(plan)
+        try data.write(to: planURL, options: .atomic)
+
+        let process = Process()
+        process.executableURL = helperURL
+        process.arguments = ["--plan", planURL.path]
+        try process.run()
+
+        NSApp.terminate(nil)
+    }
+}
+
+private struct InstallPlan: Codable {
+    let newAppPath: String
+    let targetAppPath: String
+    let backupDir: String
+    let removeQuarantine: Bool
+    let relaunchBundleID: String
+    let logFile: String
+}

--- a/GatekeeperHelper/Update/UpdateManager.swift
+++ b/GatekeeperHelper/Update/UpdateManager.swift
@@ -1,0 +1,115 @@
+import AppKit
+import Foundation
+
+final class UpdateManager {
+    static let shared = UpdateManager()
+
+    private struct LatestInfo {
+        let latestVersion: Version
+        let assetURL: URL
+    }
+
+    private var downloadController: DownloadWindowController?
+
+    private init() {}
+
+    func checkForUpdate(interactive: Bool = true) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let localVersion = Bundle.main.shortVersion ?? Version("0.0.0")!
+                let release = try await GitHubAPI.fetchLatestRelease()
+                guard let latestVersion = Version(release.tag_name) else {
+                    throw NSError(domain: "Update", code: 0, userInfo: [NSLocalizedDescriptionKey: "无法解析远端版本"])
+                }
+
+                guard let zipAsset = release.assets.first(where: { $0.name.hasSuffix(".zip") }) else {
+                    throw NSError(domain: "Update", code: 0, userInfo: [NSLocalizedDescriptionKey: "未找到可下载资产（.zip）"])
+                }
+
+                if localVersion >= latestVersion {
+                    if interactive {
+                        showAlert(title: "提示", message: "当前已是最新版本！", buttonTitles: ["好"])
+                    }
+                    return
+                }
+
+                let response = showAlert(
+                    title: "有新版本可用",
+                    message: "当前最新版本为：\(latestVersion.description)，可立即下载并安装更新",
+                    buttonTitles: ["立即更新", "下次再说"]
+                )
+
+                if response == .alertFirstButtonReturn {
+                    let info = LatestInfo(latestVersion: latestVersion, assetURL: zipAsset.browser_download_url)
+                    beginDownloadAndInstall(with: info)
+                }
+            } catch {
+                if interactive {
+                    showAlert(title: "检查失败", message: error.localizedDescription, buttonTitles: ["好"])
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    private func showAlert(title: String, message: String, buttonTitles: [String]) -> NSApplication.ModalResponse {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .informational
+        buttonTitles.forEach { alert.addButton(withTitle: $0) }
+        return alert.runModalWithSystemStyle()
+    }
+
+    private func beginDownloadAndInstall(with info: LatestInfo) {
+        let controller = DownloadWindowController()
+        downloadController = controller
+        controller.startDownload(from: info.assetURL) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let zipURL):
+                self.downloadController = nil
+                self.install(from: zipURL, info: info)
+            case .failure(let error):
+                self.downloadController = nil
+                self.showAlert(title: "下载失败", message: error.localizedDescription, buttonTitles: ["好"])
+            }
+        }
+    }
+
+    private func install(from zipURL: URL, info: LatestInfo) {
+        do {
+            let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("Update-\(info.latestVersion.description)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+
+            try Installer.unzip(zipURL, to: tempDirectory)
+            try FileManager.default.removeItem(at: zipURL)
+
+            guard let appURL = locateApp(in: tempDirectory) else {
+                throw NSError(domain: "Update", code: 0, userInfo: [NSLocalizedDescriptionKey: "未在压缩包中找到 .app"])
+            }
+
+            try Installer.installAndRelaunch(newAppURL: appURL)
+        } catch {
+            showAlert(title: "安装失败", message: error.localizedDescription, buttonTitles: ["好"])
+        }
+    }
+
+    private func locateApp(in directory: URL) -> URL? {
+        if directory.pathExtension == "app" { return directory }
+        guard let contents = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else {
+            return nil
+        }
+        for item in contents {
+            if item.pathExtension == "app" {
+                return item
+            }
+            if let found = locateApp(in: item) {
+                return found
+            }
+        }
+        return nil
+    }
+}

--- a/GatekeeperHelper/Update/Version.swift
+++ b/GatekeeperHelper/Update/Version.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct Version: Comparable, CustomStringConvertible {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    var description: String {
+        "\(major).\(minor).\(patch)"
+    }
+
+    init?(_ string: String) {
+        let trimmed = string
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
+        let components = trimmed.split(separator: ".")
+        guard !components.isEmpty else { return nil }
+
+        func value(at index: Int) -> Int {
+            guard components.indices.contains(index) else { return 0 }
+            return Int(components[index]) ?? 0
+        }
+
+        self.major = value(at: 0)
+        self.minor = value(at: 1)
+        self.patch = value(at: 2)
+    }
+
+    static func < (lhs: Version, rhs: Version) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+}
+
+extension Bundle {
+    var shortVersion: Version? {
+        guard let string = infoDictionary?["CFBundleShortVersionString"] as? String else { return nil }
+        return Version(string)
+    }
+}


### PR DESCRIPTION
## Summary
- add the current-version label and "检查更新" button to the preferences window
- implement a GitHub Releases driven update subsystem with download UI, installer handoff, and alert flows

## Testing
- Not run (macOS AppKit project cannot be built in this container)


------
https://chatgpt.com/codex/tasks/task_e_68ebdce5c7ec832382e814a62c506e0d